### PR TITLE
chore(ci): support prerelease tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,6 @@ jobs:
                   files: artifacts/**/*.deb
                   generate_release_notes: true
                   draft: false
-                  prerelease: false
+                  prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- 修改 release workflow 支持预发布版本标记
- 当 tag 包含 `-rc`、`-alpha` 或 `-beta` 后缀时，自动标记 GitHub Release 为预发布版本

## 支持的 tag 格式
| Tag | 是否预发布 |
|-----|----------|
| `v0.2.0` | 正式版 |
| `v0.2.0-rc0` | 预发布 |
| `v0.2.0-alpha1` | 预发布 |
| `v0.2.0-beta2` | 预发布 |

## Test plan
- [ ] 打一个 rc tag 验证是否正确标记为预发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项改进**
  * 完善了发布流程的版本标记机制。包含 RC、Alpha 或 Beta 标签的版本现在将自动标记为预发布版本，帮助用户更清晰地区分稳定版本和测试版本。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->