### PR TITLE
chore(build): extract version from git tag for deb package naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: "Version to release (e.g., 0.1.0)"
+                description: "Version to release (e.g., 0.1.0 or 0.2.0-rc0)"
                 required: true
 
 jobs:
@@ -27,6 +27,18 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+
+            - name: Extract version
+              id: version
+              run: |
+                  if [ -n "${{ github.event.inputs.version }}" ]; then
+                    VERSION="${{ github.event.inputs.version }}"
+                  else
+                    # Remove 'v' prefix from tag name
+                    VERSION="${GITHUB_REF_NAME#v}"
+                  fi
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "Building version: ${VERSION}"
 
             - name: Install dependencies
               run: |
@@ -58,7 +70,7 @@ jobs:
             - name: Build deb package
               run: |
                   chmod +x build_deb.sh
-                  ./build_deb.sh ${{ matrix.ros_distro }}
+                  ./build_deb.sh ${{ matrix.ros_distro }} ${{ steps.version.outputs.version }}
 
             - name: Upload artifact
               uses: actions/upload-artifact@v4
@@ -86,6 +98,6 @@ jobs:
                   files: artifacts/**/*.deb
                   generate_release_notes: true
                   draft: false
-                  prerelease: false
+                  prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- 修复 deb 包名称不包含 rc 版本标识的问题
- `build_deb.sh` 现在接受第二个参数作为版本号
- 版本号自动转换为 Debian 格式（`0.2.0-rc0` -> `0.2.0~rc0`）
- `release.yml` 从 git tag 提取版本号并传递给构建脚本
- 同时支持 rc/alpha/beta 预发布标记

## 修改文件
| 文件 | 修改 |
|-----|------|
| `build_deb.sh` | 支持 VERSION 参数，转换 Debian 版本格式 |
| `.github/workflows/release.yml` | 提取 git tag 版本号，支持 prerelease |

## 示例
| Git Tag | Deb 包名称 |
|---------|-----------|
| `v0.2.0` | `ros-kilted-wujihand_0.2.0_amd64.deb` |
| `v0.2.0-rc0` | `ros-kilted-wujihand_0.2.0~rc0_amd64.deb` |

## Test plan
- [ ] 打一个 rc tag 验证 deb 包名称是否正确包含版本号

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 支持预发布标识（RC/Alpha/Beta）并在发布流程中自动识别。
  * 提取并传递版本信息到打包流程，确保发布版本与包内版本一致。
  * 打包工具支持预发布语义转为 Debian 兼容版本格式。
  * 引入独立构建目录并改进清理逻辑，提升构建隔离性与可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->