### PR TITLE
docs: standardize placeholder format from ${} to <>

### DIFF
--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -49,7 +49,7 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 
 ### Run Multi-hand Demos
 
-When running demo scripts in a multi-hand environment, specify the target hand with `--ros-args -p hand_name:=<name>`:
+When running demo scripts in a multi-hand environment, specify the target hand with `--ros-args -p hand_name:=<hand-name>`:
 
 ```bash
 # Run wave demo on the left hand

--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -30,11 +30,11 @@ When controlling multiple dexterous hands simultaneously, use serial numbers and
 
 If opening a new terminal, you need to source the ROS2 environment again
 ```bash
-# Source ROS2 environment, replace ${distro} with your ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Source ROS2 environment, replace <distro> with your ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 # If built from source, overlay the workspace (Deb package users can skip)
-# Replace ${WORKSPACE} with your workspace path, e.g., ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# Replace <workspace> with your workspace path, e.g., ~/wujihandros2
+source <workspace>/install/setup.bash
 ```
 
 ```bash

--- a/docs/external/en/installation.mdx
+++ b/docs/external/en/installation.mdx
@@ -42,9 +42,9 @@ Please ensure your system meets the [System Requirements](#system-requirements) 
 Before installing the ROS2 driver, you need to install the Wuji Hand SDK:
 
 ```bash
-# Replace ${SDK_VERSION} with the actual version number, e.g., 1.5.0
-wget https://github.com/wuji-technology/wujihandpy/releases/download/v${SDK_VERSION}/wujihandcpp-${SDK_VERSION}-amd64.deb
-sudo apt install ./wujihandcpp-${SDK_VERSION}-amd64.deb
+# Replace <version> with the actual version number, e.g., 1.5.0
+wget https://github.com/wuji-technology/wujihandpy/releases/download/v<version>/wujihandcpp-<version>-amd64.deb
+sudo apt install ./wujihandcpp-<version>-amd64.deb
 ```
 
 ### Install ROS2 Driver
@@ -87,8 +87,8 @@ cd wujihandros2
 # Fetch URDF model submodule (required)
 git submodule update --init --recursive
 
-# Source ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Source ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 
 # Build
 colcon build
@@ -111,9 +111,9 @@ sudo apt update
 sudo apt install -y ros-humble-ros-base ros-humble-robot-state-publisher \
     ros-humble-sensor-msgs ros-humble-std-msgs
 
-# Download and install from GitHub Releases (replace ${VERSION} with actual version)
-wget https://github.com/wuji-technology/wujihandros2/releases/download/v${VERSION}/ros-humble-wujihand_${VERSION}_amd64.deb
-sudo apt install ./ros-humble-wujihand_${VERSION}_amd64.deb
+# Download and install from GitHub Releases (replace <version> with actual version)
+wget https://github.com/wuji-technology/wujihandros2/releases/download/v<version>/ros-humble-wujihand_<version>_amd64.deb
+sudo apt install ./ros-humble-wujihand_<version>_amd64.deb
 ```
 
 **Ubuntu 24.04 (ROS2 Kilted)**
@@ -124,7 +124,7 @@ sudo apt update
 sudo apt install -y ros-kilted-ros-base ros-kilted-robot-state-publisher \
     ros-kilted-sensor-msgs ros-kilted-std-msgs
 
-# Download and install from GitHub Releases (replace ${VERSION} with actual version)
-wget https://github.com/wuji-technology/wujihandros2/releases/download/v${VERSION}/ros-kilted-wujihand_${VERSION}_amd64.deb
-sudo apt install ./ros-kilted-wujihand_${VERSION}_amd64.deb
+# Download and install from GitHub Releases (replace <version> with actual version)
+wget https://github.com/wuji-technology/wujihandros2/releases/download/v<version>/ros-kilted-wujihand_<version>_amd64.deb
+sudo apt install ./ros-kilted-wujihand_<version>_amd64.deb
 ```

--- a/docs/external/en/quick-start.mdx
+++ b/docs/external/en/quick-start.mdx
@@ -44,7 +44,7 @@ ros2 run wujihand_bringup wave_demo.py
 ```
 
 <Callout type="info">
-When multiple hands are connected, specify the target hand with `--ros-args -p hand_name:=<name>`. See [Multi-hand Configuration](./configuration#multi-hand-configuration) for details.
+When multiple hands are connected, specify the target hand with `--ros-args -p hand_name:=<hand-name>`. See [Multi-hand Configuration](./configuration#multi-hand-configuration) for details.
 </Callout>
 
 ## Launch RViz Visualization

--- a/docs/external/en/quick-start.mdx
+++ b/docs/external/en/quick-start.mdx
@@ -5,11 +5,11 @@ title: Quick Start
 ## Launch the Driver
 
 ```bash
-# Source ROS2 environment, replace ${distro} with your ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Source ROS2 environment, replace <distro> with your ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 # If built from source, overlay the workspace (Deb package users can skip)
-# Replace ${WORKSPACE} with your workspace path, e.g., ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# Replace <workspace> with your workspace path, e.g., ~/wujihandros2
+source <workspace>/install/setup.bash
 
 # Launch the driver
 ros2 launch wujihand_bringup wujihand.launch.py
@@ -27,11 +27,11 @@ On successful launch, you will see the following output:
 Open a new terminal and check the joint states:
 
 ```bash
-# Source ROS2 environment, replace ${distro} with your ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Source ROS2 environment, replace <distro> with your ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 # If built from source, overlay the workspace (Deb package users can skip)
-# Replace ${WORKSPACE} with your workspace path, e.g., ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# Replace <workspace> with your workspace path, e.g., ~/wujihandros2
+source <workspace>/install/setup.bash
 
 ros2 topic echo /hand_0/joint_states --once
 ```

--- a/docs/external/en/ros2-interface.mdx
+++ b/docs/external/en/ros2-interface.mdx
@@ -215,8 +215,8 @@ if __name__ == '__main__':
 
 2. Start the driver in terminal 1:
 ```bash
-# Load ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Load ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 # Navigate to driver workspace and run the following commands to source it (skip if installed via Deb)
 cd <workspace>
 source install/setup.bash
@@ -225,8 +225,8 @@ ros2 launch wujihand_bringup wujihand.launch.py
 
 3. Run the example code in terminal 2:
 ```bash
-# Load ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Load ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 python3 wujihand_controller.py
 ```
 
@@ -325,8 +325,8 @@ C++ examples require creating a ROS2 package to compile.
 1. Create a test package:
 ```bash
 cd ~/test
-# Load ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Load ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 ros2 pkg create --build-type ament_cmake test_wujihand --dependencies rclcpp sensor_msgs
 ```
 
@@ -341,8 +341,8 @@ install(TARGETS wujihand_controller DESTINATION lib/${PROJECT_NAME})
 
 4. Start the driver in terminal 1:
 ```bash
-# Load ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Load ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 # Navigate to driver workspace and run the following commands to source it (skip if installed via Deb)
 cd <workspace>
 source install/setup.bash
@@ -351,8 +351,8 @@ ros2 launch wujihand_bringup wujihand.launch.py
 
 5. Build and run in terminal 2:
 ```bash
-# Load ROS2 environment, replace ${distro} with your installed ROS2 distribution
-source /opt/ros/${distro}/setup.bash
+# Load ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
 cd ~/test
 colcon build --packages-select test_wujihand
 source ~/test/install/setup.bash

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -49,7 +49,7 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 
 ### 运行多手演示
 
-多手环境下运行演示脚本时，通过 `--ros-args -p hand_name:=<名称>` 指定目标手：
+多手环境下运行演示脚本时，通过 `--ros-args -p hand_name:=<hand-name>` 指定目标手：
 
 ```bash
 # 对左手运行波浪演示

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -30,11 +30,11 @@ title: 启动与配置
 
 如果打开新终端，需要重新加载 ROS2 环境
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 # 如使用源码编译，请叠加工作空间（Deb 包安装可跳过）
-# 将 ${WORKSPACE} 替换为实际工作空间路径，如 ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# 将 <workspace> 替换为实际工作空间路径，如 ~/wujihandros2
+source <workspace>/install/setup.bash
 ```
 
 ```bash

--- a/docs/external/zh/installation.mdx
+++ b/docs/external/zh/installation.mdx
@@ -42,9 +42,9 @@ title: 安装指南
 在安装 ROS2 驱动之前，需要先安装 Wuji Hand SDK：
 
 ```bash
-# 替换 ${SDK_VERSION} 为实际版本号，如 1.5.0
-wget https://github.com/wuji-technology/wujihandpy/releases/download/v${SDK_VERSION}/wujihandcpp-${SDK_VERSION}-amd64.deb
-sudo apt install ./wujihandcpp-${SDK_VERSION}-amd64.deb
+# 替换 <version> 为实际版本号，如 1.5.0
+wget https://github.com/wuji-technology/wujihandpy/releases/download/v<version>/wujihandcpp-<version>-amd64.deb
+sudo apt install ./wujihandcpp-<version>-amd64.deb
 ```
 
 ### 安装 ROS2 驱动
@@ -87,8 +87,8 @@ cd wujihandros2
 # 拉取 URDF 模型子模块（必须）
 git submodule update --init --recursive
 
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 
 # 编译
 colcon build
@@ -111,9 +111,9 @@ sudo apt update
 sudo apt install -y ros-humble-ros-base ros-humble-robot-state-publisher \
     ros-humble-sensor-msgs ros-humble-std-msgs
 
-# 从 GitHub Releases 下载并安装（替换 ${VERSION} 为实际版本号）
-wget https://github.com/wuji-technology/wujihandros2/releases/download/v${VERSION}/ros-humble-wujihand_${VERSION}_amd64.deb
-sudo apt install ./ros-humble-wujihand_${VERSION}_amd64.deb
+# 从 GitHub Releases 下载并安装（替换 <version> 为实际版本号）
+wget https://github.com/wuji-technology/wujihandros2/releases/download/v<version>/ros-humble-wujihand_<version>_amd64.deb
+sudo apt install ./ros-humble-wujihand_<version>_amd64.deb
 ```
 
 **Ubuntu 24.04 (ROS2 Kilted)**
@@ -124,7 +124,7 @@ sudo apt update
 sudo apt install -y ros-kilted-ros-base ros-kilted-robot-state-publisher \
     ros-kilted-sensor-msgs ros-kilted-std-msgs
 
-# 从 GitHub Releases 下载并安装（替换 ${VERSION} 为实际版本号）
-wget https://github.com/wuji-technology/wujihandros2/releases/download/v${VERSION}/ros-kilted-wujihand_${VERSION}_amd64.deb
-sudo apt install ./ros-kilted-wujihand_${VERSION}_amd64.deb
+# 从 GitHub Releases 下载并安装（替换 <version> 为实际版本号）
+wget https://github.com/wuji-technology/wujihandros2/releases/download/v<version>/ros-kilted-wujihand_<version>_amd64.deb
+sudo apt install ./ros-kilted-wujihand_<version>_amd64.deb
 ```

--- a/docs/external/zh/quick-start.mdx
+++ b/docs/external/zh/quick-start.mdx
@@ -5,11 +5,11 @@ title: 快速开始
 ## 启动驱动
 
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 # 如使用源码编译，请叠加工作空间（Deb 包安装可跳过）
-# 将 ${WORKSPACE} 替换为实际工作空间路径，如 ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# 将 <workspace> 替换为实际工作空间路径，如 ~/wujihandros2
+source <workspace>/install/setup.bash
 
 # 启动驱动
 ros2 launch wujihand_bringup wujihand.launch.py
@@ -27,11 +27,11 @@ ros2 launch wujihand_bringup wujihand.launch.py
 打开新终端，查看关节状态：
 
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 # 如使用源码编译，请叠加工作空间（Deb 包安装可跳过）
-# 将 ${WORKSPACE} 替换为实际工作空间路径，如 ~/wujihandros2
-source ${WORKSPACE}/install/setup.bash
+# 将 <workspace> 替换为实际工作空间路径，如 ~/wujihandros2
+source <workspace>/install/setup.bash
 
 ros2 topic echo /hand_0/joint_states --once
 ```

--- a/docs/external/zh/quick-start.mdx
+++ b/docs/external/zh/quick-start.mdx
@@ -44,7 +44,7 @@ ros2 run wujihand_bringup wave_demo.py
 ```
 
 <Callout type="info">
-连接多只灵巧手时，需通过 `--ros-args -p hand_name:=<名称>` 指定目标手。详见[多手配置](./configuration#多手配置)。
+连接多只灵巧手时，需通过 `--ros-args -p hand_name:=<hand-name>` 指定目标手。详见[多手配置](./configuration#多手配置)。
 </Callout>
 
 ## 启动 RViz 可视化

--- a/docs/external/zh/ros2-interface.mdx
+++ b/docs/external/zh/ros2-interface.mdx
@@ -215,8 +215,8 @@ if __name__ == '__main__':
 
 2. 在终端 1 启动驱动：
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 # 进入驱动工作区后，执行以下命令加载环境（Deb 安装可跳过此步）
 cd <workspace>
 source install/setup.bash
@@ -225,8 +225,8 @@ ros2 launch wujihand_bringup wujihand.launch.py
 
 3. 在终端 2 运行示例代码：
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 python3 wujihand_controller.py
 ```
 
@@ -325,8 +325,8 @@ C++ 示例需要创建 ROS2 包来编译。
 1. 创建测试包：
 ```bash
 cd ~/test
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 ros2 pkg create --build-type ament_cmake test_wujihand --dependencies rclcpp sensor_msgs
 ```
 
@@ -341,8 +341,8 @@ install(TARGETS wujihand_controller DESTINATION lib/${PROJECT_NAME})
 
 4. 在终端 1 启动驱动：
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 # 进入驱动工作区后，执行以下命令加载环境（Deb 安装可跳过此步）
 cd <workspace>
 source install/setup.bash
@@ -351,8 +351,8 @@ ros2 launch wujihand_bringup wujihand.launch.py
 
 5. 在终端 2 编译并运行：
 ```bash
-# 加载 ROS2 环境，替换 ${distro} 为实际安装的 ROS2 发行版
-source /opt/ros/${distro}/setup.bash
+# 加载 ROS2 环境，替换 <distro> 为实际安装的 ROS2 发行版
+source /opt/ros/<distro>/setup.bash
 cd ~/test
 colcon build --packages-select test_wujihand
 source ~/test/install/setup.bash


### PR DESCRIPTION
## Summary
- Replace `${distro}`, `${WORKSPACE}`, `${SDK_VERSION}`, and `${VERSION}` placeholders with `<distro>`, `<workspace>`, and `<version>` angle bracket format
- Preserve `${PROJECT_NAME}` as it is a real CMake variable

## Test plan
- [ ] Verify code blocks render correctly on docs site
- [ ] Confirm no remaining `${}` placeholders (except `${PROJECT_NAME}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 统一并简化安装、快速入门、配置与 ROS2 相关指南中的占位符格式（将 shell 风格变量替换为尖括号形式），使示例命令更易替换和理解。
  * 规范多手演示中的手名占位符为带短横的形式（如 hand-name），并同步中英文内容以保持一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->