### PR TITLE
chore(ci): 接入 wuji-docs-center 中心 docs-followup（caller）

### DIFF
--- a/.github/docs-sync-public-packages.txt
+++ b/.github/docs-sync-public-packages.txt
@@ -1,0 +1,12 @@
+# Public path prefixes — consumed by the docs-followup reusable workflow.
+# Each non-comment, non-blank line is an anchored path prefix (matched against
+# `git diff --name-only` of the merged PR). A change touching any of these is
+# treated as user-visible and triggers docs follow-up analysis.
+
+# ROS2 对外接口：消息定义、launch、驱动
+wujihand_msgs/
+wujihand_bringup/
+wujihand_driver/
+
+# 对外文档源
+docs/external/

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -1,0 +1,14 @@
+name: Docs Follow-up Callback
+
+# Thin caller for the centralized docs-followup callback in wuji-docs-center.
+# Closes the loop when the maintainer comments /docs-done or /docs-skip on a PR
+# tagged `docs:followup`. All logic lives in the reusable workflow.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  docs-followup-callback:
+    uses: wuji-technology/wuji-docs-center/.github/workflows/docs-followup-callback.yml@main
+    secrets: inherit

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -1,0 +1,20 @@
+name: Post-Merge Docs Follow-up
+
+# Thin caller for the centralized docs-followup pipeline in wuji-docs-center.
+# All logic lives in the reusable workflow; this repo only provides the trigger,
+# the public-surface list (.github/docs-sync-public-packages.txt), and org
+# secrets via `secrets: inherit`.
+#
+# Prerequisites (one-time, org-wide, already in place): wuji-docs-center exposes
+# its Actions to the org (Settings -> Actions -> Access); the reusable workflow
+# checks out wuji-docs-center via an App token internally.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  docs-followup:
+    uses: wuji-technology/wuji-docs-center/.github/workflows/post-merge-docs-followup.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

docs-followup 中心化阶段二 Wave 2：接入 wuji-docs-center 中心 reusable workflow（caller 模式）。

- 新增 2 个薄 caller（`docs-followup.yml` + `docs-followup-callback.yml`），引用 `wuji-technology/wuji-docs-center/.github/workflows/...@main` + `secrets: inherit`
- 新增 `.github/docs-sync-public-packages.txt`（本仓库公开面路径清单）
- 逻辑全在中心维护，本仓库零脚本；旧通知 workflow 保留不动

合入 main 后改动触及公开面清单路径且非内部前缀时，自动派单文档跟进，收尾走 `/docs-done` `/docs-skip` 或本地 skill。

> 经 Fork and Pull 提交（本仓库 ruleset 限制直接建分支）。

## Test plan

- [x] caller workflow actionlint 通过
- [x] 公开面清单路径在本仓库 main 真实存在
- [ ] 合入后挑改公开面的真实 PR 观察派单链路

## 前置
依赖 wuji-docs-center 已开放组织级 Actions 访问 + reusable 已在 main（#128/#129）。