### PR TITLE
Fix wuji-description submodule commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ compile_commands.json
 # Python
 __pycache__/
 *.pyc
+.venv
 
 # Environment setup script (local only)
 env.sh

--- a/wujihand_bringup/launch/common.py
+++ b/wujihand_bringup/launch/common.py
@@ -86,7 +86,7 @@ def spawn_robot_state_publisher(context):
         List containing robot_state_publisher Node, or empty list on failure
     """
     hand_name = LaunchConfiguration("hand_name").perform(context)
-    wuji_hand_description_dir = get_package_share_directory("wuji_hand_description")
+    wuji_description_dir = get_package_share_directory("wuji_description")
 
     # Detect handedness from driver node
     hand_type = detect_handedness(hand_name)
@@ -100,7 +100,7 @@ def spawn_robot_state_publisher(context):
 
     # Read the pre-generated ROS URDF file
     urdf_file = os.path.join(
-        wuji_hand_description_dir, "urdf", f"{hand_type}-ros.urdf"
+        wuji_description_dir, "urdf", f"{hand_type}-ros.urdf"
     )
     try:
         with open(urdf_file, "r") as f:

--- a/wujihand_bringup/launch/wujihand.launch.py
+++ b/wujihand_bringup/launch/wujihand.launch.py
@@ -17,7 +17,7 @@ from common import spawn_robot_state_publisher, detect_handedness
 def spawn_rviz(context):
     """Spawn RViz node with proper namespace and handedness-specific config."""
     hand_name = LaunchConfiguration("hand_name").perform(context)
-    wuji_hand_description_dir = get_package_share_directory("wuji_hand_description")
+    wuji_description_dir = get_package_share_directory("wuji_description")
 
     # Detect handedness from driver node
     hand_type = detect_handedness(hand_name)
@@ -25,7 +25,7 @@ def spawn_rviz(context):
         # Fallback to left.rviz if detection fails
         hand_type = "left"
 
-    rviz_config = os.path.join(wuji_hand_description_dir, "rviz", f"{hand_type}.rviz")
+    rviz_config = os.path.join(wuji_description_dir, "rviz", f"{hand_type}.rviz")
 
     return [
         Node(

--- a/wujihand_bringup/package.xml
+++ b/wujihand_bringup/package.xml
@@ -13,7 +13,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>wujihand_driver</exec_depend>
-  <exec_depend>wuji_hand_description</exec_depend>
+  <exec_depend>wuji_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>launch</exec_depend>


### PR DESCRIPTION
## Summary
- Update the `external/wuji-description` submodule gitlink to `1b22c252ea3d9c6c403f862a5c13bd18cdfe7987` from the renamed `wuji-description` repository.
- Update `wujihand_bringup` launch files and runtime dependency from `wuji_hand_description` to `wuji_description`, matching the package name in the new submodule layout.
- Ignore the local `.venv` directory.

## Test Plan
- `source /opt/ros/kilted/setup.bash && colcon --log-base /tmp/wujihandros2-colcon-pr-KmxM3s/log build --paths wujihand_msgs wujihand_driver wujihand_bringup external/wuji-description/hand/body --build-base /tmp/wujihandros2-colcon-pr-KmxM3s/build --install-base /tmp/wujihandros2-colcon-pr-KmxM3s/install --event-handlers console_direct+`
- `source /opt/ros/kilted/setup.bash && source /tmp/wujihandros2-colcon-pr-KmxM3s/install/setup.bash && ros2 launch wujihand_bringup wujihand.launch.py --show-args`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated project dependencies and submodule references to use a new description package
  * Improved development environment configuration by adding virtual environment directory to ignore rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->