### PR TITLE
ci: clarify GitHub Actions workflow semantics

### DIFF
--- a/.github/workflows/auto-release-on-pr.yml
+++ b/.github/workflows/auto-release-on-pr.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-tags: true

--- a/.github/workflows/auto-release-on-pr.yml
+++ b/.github/workflows/auto-release-on-pr.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-tags: true

--- a/.github/workflows/auto-release-on-pr.yml
+++ b/.github/workflows/auto-release-on-pr.yml
@@ -1,4 +1,4 @@
-name: Auto Release on PR Merge
+name: Create Release Tag from Merged PR
 
 on:
   pull_request:
@@ -6,8 +6,8 @@ on:
     branches: [master]
 
 jobs:
-  create-tag:
-    name: Create release tag
+  create-release-tag:
+    name: Create release tag from merged release PR
     if: >-
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'auto-release') &&

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: Publish Changelog Release Notes
 
 on:
   push:
@@ -9,11 +9,14 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  publish-changelog-release-notes:
+    name: Publish changelog release notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Auto Release
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Run shared changelog release action
         uses: wuji-technology/.github/actions/auto-release@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,11 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v4
 
       - name: Run shared changelog release action
-        uses: wuji-technology/.github/actions/auto-release@048e1cde71208eed2536884ab5fd085e9392f3f6 # v1
+        uses: wuji-technology/.github/actions/auto-release@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Run shared changelog release action
-        uses: wuji-technology/.github/actions/auto-release@v1
+        uses: wuji-technology/.github/actions/auto-release@048e1cde71208eed2536884ab5fd085e9392f3f6 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
         branches: [master, main]
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     source-build:
         name: Build ROS workspace (${{ matrix.ros_distro }}, ${{ matrix.os }})
@@ -25,7 +28,9 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
 
             - name: Install ROS build dependencies
               run: |
@@ -88,7 +93,9 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
 
             - name: Install Debian packaging dependencies
               run: |
@@ -126,7 +133,7 @@ jobs:
                   ./build_deb.sh ${{ matrix.ros_distro }}
 
             - name: Upload Debian package artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
@@ -137,7 +144,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
 
             - name: Install clang-format
               run: sudo apt-get update && sudo apt-get install -y clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     build-deb:
         runs-on: ubuntu-latest
         needs: build
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'))
         strategy:
             matrix:
                 include:
@@ -141,4 +141,51 @@ jobs:
 
             - name: Check C++ formatting
               run: |
-                  find . -name "*.cpp" -o -name "*.hpp" | head -20 | xargs clang-format --dry-run --Werror || echo "Format check completed"
+                  find . \( -name "*.cpp" -o -name "*.hpp" \) -print0 | xargs -0 -r clang-format --dry-run --Werror
+
+    ci-gate:
+        runs-on: ubuntu-latest
+        needs: [build, build-deb, lint]
+        if: always()
+        steps:
+            - name: Verify required CI jobs
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  build_result="${{ needs.build.result }}"
+                  build_deb_result="${{ needs['build-deb'].result }}"
+                  lint_result="${{ needs.lint.result }}"
+
+                  echo "build: ${build_result}"
+                  echo "build-deb: ${build_deb_result}"
+                  echo "lint: ${lint_result}"
+
+                  failed=0
+
+                  if [[ "${build_result}" != "success" ]]; then
+                      echo "build did not pass"
+                      failed=1
+                  fi
+
+                  if [[ "${lint_result}" != "success" ]]; then
+                      echo "lint did not pass"
+                      failed=1
+                  fi
+
+                  require_deb=false
+                  if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" ]]; then
+                      require_deb=true
+                  fi
+
+                  if [[ "${require_deb}" == "true" ]]; then
+                      if [[ "${build_deb_result}" != "success" ]]; then
+                          echo "build-deb did not pass"
+                          failed=1
+                      fi
+                  elif [[ "${build_deb_result}" != "success" && "${build_deb_result}" != "skipped" ]]; then
+                      echo "build-deb finished with an unexpected result"
+                      failed=1
+                  fi
+
+                  exit "${failed}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
         branches: [master, main]
     workflow_dispatch:
 
-permissions:
-    contents: read
-
 jobs:
     source-build:
         name: Build ROS workspace (${{ matrix.ros_distro }}, ${{ matrix.os }})
@@ -28,9 +25,7 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-              with:
-                  persist-credentials: false
+              uses: actions/checkout@v4
 
             - name: Install ROS build dependencies
               run: |
@@ -93,9 +88,7 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-              with:
-                  persist-credentials: false
+              uses: actions/checkout@v4
 
             - name: Install Debian packaging dependencies
               run: |
@@ -133,7 +126,7 @@ jobs:
                   ./build_deb.sh ${{ matrix.ros_distro }}
 
             - name: Upload Debian package artifact
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
@@ -144,9 +137,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout source
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-              with:
-                  persist-credentials: false
+              uses: actions/checkout@v4
 
             - name: Install clang-format
               run: sudo apt-get update && sudo apt-get install -y clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Validate Build and Packaging
 
 on:
     push:
@@ -8,7 +8,8 @@ on:
     workflow_dispatch:
 
 jobs:
-    build:
+    source-build:
+        name: Build ROS workspace (${{ matrix.ros_distro }}, ${{ matrix.os }})
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -23,10 +24,10 @@ jobs:
             image: ros:${{ matrix.ros_distro }}-ros-base
 
         steps:
-            - name: Checkout
+            - name: Checkout source
               uses: actions/checkout@v4
 
-            - name: Install dependencies
+            - name: Install ROS build dependencies
               run: |
                   apt-get update
                   apt-get install -y wget
@@ -54,13 +55,13 @@ jobs:
                     ros-${{ matrix.ros_distro }}-robot-state-publisher \
                     ros-${{ matrix.ros_distro }}-xacro
 
-            - name: Build
+            - name: Build ROS workspace
               run: |
                   source /opt/ros/${{ matrix.ros_distro }}/setup.bash
                   colcon build --symlink-install
               shell: bash
 
-            - name: Test
+            - name: Run ROS tests (non-blocking)
               run: |
                   source /opt/ros/${{ matrix.ros_distro }}/setup.bash
                   source install/setup.bash
@@ -69,9 +70,10 @@ jobs:
               shell: bash
               continue-on-error: true
 
-    build-deb:
+    debian-package:
+        name: Build Debian package (${{ matrix.ros_distro }}, ${{ matrix.os }})
         runs-on: ubuntu-latest
-        needs: build
+        needs: source-build
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'))
         strategy:
             matrix:
@@ -85,10 +87,10 @@ jobs:
             image: ros:${{ matrix.ros_distro }}-ros-base
 
         steps:
-            - name: Checkout
+            - name: Checkout source
               uses: actions/checkout@v4
 
-            - name: Install dependencies
+            - name: Install Debian packaging dependencies
               run: |
                   apt-get update
                   apt-get install -y wget dpkg-dev
@@ -115,7 +117,7 @@ jobs:
                     ros-${{ matrix.ros_distro }}-std-msgs \
                     ros-${{ matrix.ros_distro }}-robot-state-publisher
 
-            - name: Build deb package
+            - name: Build Debian package
               run: |
                   # Fix git dubious ownership error in CI
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -123,17 +125,18 @@ jobs:
                   chmod +x build_deb.sh
                   ./build_deb.sh ${{ matrix.ros_distro }}
 
-            - name: Upload deb artifact
+            - name: Upload Debian package artifact
               uses: actions/upload-artifact@v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
                   retention-days: 30
 
-    lint:
+    format-check:
+        name: Check C++ formatting
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout
+            - name: Checkout source
               uses: actions/checkout@v4
 
             - name: Install clang-format
@@ -143,45 +146,45 @@ jobs:
               run: |
                   find . \( -name "*.cpp" -o -name "*.hpp" \) -print0 | xargs -0 -r clang-format --dry-run --Werror
 
-    ci-gate:
+    required-validation:
+        name: Required validation checks
         runs-on: ubuntu-latest
-        needs: [build, build-deb, lint]
+        needs: [source-build, debian-package, format-check]
         if: always()
         env:
-            REQUIRE_DEB: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
+            REQUIRE_DEBIAN_PACKAGE: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
+            SOURCE_BUILD_RESULT: ${{ needs['source-build'].result }}
+            DEBIAN_PACKAGE_RESULT: ${{ needs['debian-package'].result }}
+            FORMAT_CHECK_RESULT: ${{ needs['format-check'].result }}
         steps:
-            - name: Verify required CI jobs
+            - name: Verify required validation jobs
               shell: bash
               run: |
                   set -euo pipefail
 
-                  build_result="${{ needs.build.result }}"
-                  build_deb_result="${{ needs['build-deb'].result }}"
-                  lint_result="${{ needs.lint.result }}"
-
-                  echo "build: ${build_result}"
-                  echo "build-deb: ${build_deb_result}"
-                  echo "lint: ${lint_result}"
+                  echo "source build: ${SOURCE_BUILD_RESULT}"
+                  echo "Debian package: ${DEBIAN_PACKAGE_RESULT}"
+                  echo "format check: ${FORMAT_CHECK_RESULT}"
 
                   failed=0
 
-                  if [[ "${build_result}" != "success" ]]; then
-                      echo "build did not pass"
+                  if [[ "${SOURCE_BUILD_RESULT}" != "success" ]]; then
+                      echo "source build did not pass"
                       failed=1
                   fi
 
-                  if [[ "${lint_result}" != "success" ]]; then
-                      echo "lint did not pass"
+                  if [[ "${FORMAT_CHECK_RESULT}" != "success" ]]; then
+                      echo "format check did not pass"
                       failed=1
                   fi
 
-                  if [[ "${REQUIRE_DEB}" == "true" ]]; then
-                      if [[ "${build_deb_result}" != "success" ]]; then
-                          echo "build-deb did not pass"
+                  if [[ "${REQUIRE_DEBIAN_PACKAGE}" == "true" ]]; then
+                      if [[ "${DEBIAN_PACKAGE_RESULT}" != "success" ]]; then
+                          echo "Debian package build did not pass"
                           failed=1
                       fi
-                  elif [[ "${build_deb_result}" != "success" && "${build_deb_result}" != "skipped" ]]; then
-                      echo "build-deb finished with an unexpected result"
+                  elif [[ "${DEBIAN_PACKAGE_RESULT}" != "success" && "${DEBIAN_PACKAGE_RESULT}" != "skipped" ]]; then
+                      echo "Debian package build finished with an unexpected result"
                       failed=1
                   fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,38 +152,39 @@ jobs:
         needs: [source-build, debian-package, format-check]
         if: always()
         env:
-            REQUIRE_DEBIAN_PACKAGE: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
-            SOURCE_BUILD_RESULT: ${{ needs['source-build'].result }}
-            DEBIAN_PACKAGE_RESULT: ${{ needs['debian-package'].result }}
-            FORMAT_CHECK_RESULT: ${{ needs['format-check'].result }}
+            REQUIRE_DEB: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
         steps:
             - name: Verify required validation jobs
               shell: bash
               run: |
                   set -euo pipefail
 
-                  echo "source build: ${SOURCE_BUILD_RESULT}"
-                  echo "Debian package: ${DEBIAN_PACKAGE_RESULT}"
-                  echo "format check: ${FORMAT_CHECK_RESULT}"
+                  source_build_result="${{ needs['source-build'].result }}"
+                  debian_package_result="${{ needs['debian-package'].result }}"
+                  format_check_result="${{ needs['format-check'].result }}"
+
+                  echo "source build: ${source_build_result}"
+                  echo "Debian package: ${debian_package_result}"
+                  echo "format check: ${format_check_result}"
 
                   failed=0
 
-                  if [[ "${SOURCE_BUILD_RESULT}" != "success" ]]; then
+                  if [[ "${source_build_result}" != "success" ]]; then
                       echo "source build did not pass"
                       failed=1
                   fi
 
-                  if [[ "${FORMAT_CHECK_RESULT}" != "success" ]]; then
+                  if [[ "${format_check_result}" != "success" ]]; then
                       echo "format check did not pass"
                       failed=1
                   fi
 
-                  if [[ "${REQUIRE_DEBIAN_PACKAGE}" == "true" ]]; then
-                      if [[ "${DEBIAN_PACKAGE_RESULT}" != "success" ]]; then
+                  if [[ "${REQUIRE_DEB}" == "true" ]]; then
+                      if [[ "${debian_package_result}" != "success" ]]; then
                           echo "Debian package build did not pass"
                           failed=1
                       fi
-                  elif [[ "${DEBIAN_PACKAGE_RESULT}" != "success" && "${DEBIAN_PACKAGE_RESULT}" != "skipped" ]]; then
+                  elif [[ "${debian_package_result}" != "success" && "${debian_package_result}" != "skipped" ]]; then
                       echo "Debian package build finished with an unexpected result"
                       failed=1
                   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
         runs-on: ubuntu-latest
         needs: [build, build-deb, lint]
         if: always()
+        env:
+            REQUIRE_DEB: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
         steps:
             - name: Verify required CI jobs
               shell: bash
@@ -173,12 +175,7 @@ jobs:
                       failed=1
                   fi
 
-                  require_deb=false
-                  if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" ]]; then
-                      require_deb=true
-                  fi
-
-                  if [[ "${require_deb}" == "true" ]]; then
+                  if [[ "${REQUIRE_DEB}" == "true" ]]; then
                       if [[ "${build_deb_result}" != "success" ]]; then
                           echo "build-deb did not pass"
                           failed=1

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -14,7 +14,6 @@ jobs:
     name: Disabled docs follow-up callback
     if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Explain disabled docs follow-up callback
         run: |

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -1,4 +1,4 @@
-name: Docs Follow-up Callback
+name: Docs Follow-up Callback (disabled)
 
 # This repository is public, so it cannot call reusable workflows from the
 # private wuji-docs-center repository. Keep this workflow as an explicit no-op
@@ -10,10 +10,11 @@ on:
     types: [created]
 
 jobs:
-  docs-followup-callback:
+  disabled-docs-followup-callback:
+    name: Disabled docs follow-up callback
     if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Skip private reusable workflow
+      - name: Explain disabled docs follow-up callback
         run: |
           echo "Docs follow-up callback is disabled for public caller repositories."

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -1,8 +1,9 @@
 name: Docs Follow-up Callback
 
-# Thin caller for the centralized docs-followup callback in wuji-docs-center.
-# Closes the loop when the maintainer comments /docs-done or /docs-skip on a PR
-# tagged `docs:followup`. All logic lives in the reusable workflow.
+# This repository is public, so it cannot call reusable workflows from the
+# private wuji-docs-center repository. Keep this workflow as an explicit no-op
+# until the docs follow-up automation is exposed through a public reusable
+# workflow or moved into this repository.
 
 on:
   issue_comment:
@@ -10,5 +11,8 @@ on:
 
 jobs:
   docs-followup-callback:
-    uses: wuji-technology/wuji-docs-center/.github/workflows/docs-followup-callback.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip private reusable workflow
+        run: |
+          echo "Docs follow-up callback is disabled for public caller repositories."

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -14,6 +14,7 @@ jobs:
     name: Disabled docs follow-up callback
     if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Explain disabled docs follow-up callback
         run: |

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   docs-followup-callback:
+    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip private reusable workflow

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -1,13 +1,9 @@
 name: Post-Merge Docs Follow-up
 
-# Thin caller for the centralized docs-followup pipeline in wuji-docs-center.
-# All logic lives in the reusable workflow; this repo only provides the trigger,
-# the public-surface list (.github/docs-sync-public-packages.txt), and org
-# secrets via `secrets: inherit`.
-#
-# Prerequisites (one-time, org-wide, already in place): wuji-docs-center exposes
-# its Actions to the org (Settings -> Actions -> Access); the reusable workflow
-# checks out wuji-docs-center via an App token internally.
+# This repository is public, so it cannot call reusable workflows from the
+# private wuji-docs-center repository. Keep this workflow as an explicit no-op
+# until the docs follow-up automation is exposed through a public reusable
+# workflow or moved into this repository.
 
 on:
   pull_request:
@@ -16,5 +12,8 @@ on:
 
 jobs:
   docs-followup:
-    uses: wuji-technology/wuji-docs-center/.github/workflows/post-merge-docs-followup.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip private reusable workflow
+        run: |
+          echo "Docs follow-up is disabled for public caller repositories."

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -13,8 +13,9 @@ on:
 jobs:
   disabled-docs-followup:
     name: Disabled post-merge docs follow-up
-    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
+    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Explain disabled docs follow-up
         run: |

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -1,4 +1,4 @@
-name: Post-Merge Docs Follow-up
+name: Post-Merge Docs Follow-up (disabled)
 
 # This repository is public, so it cannot call reusable workflows from the
 # private wuji-docs-center repository. Keep this workflow as an explicit no-op
@@ -11,10 +11,11 @@ on:
     branches: [main]
 
 jobs:
-  docs-followup:
+  disabled-docs-followup:
+    name: Disabled post-merge docs follow-up
     if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Skip private reusable workflow
+      - name: Explain disabled docs follow-up
         run: |
           echo "Docs follow-up is disabled for public caller repositories."

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -13,9 +13,8 @@ on:
 jobs:
   disabled-docs-followup:
     name: Disabled post-merge docs follow-up
-    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' && github.event.pull_request.merged == true }}
+    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Explain disabled docs follow-up
         run: |

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   docs-followup:
+    if: ${{ vars.DOCS_FOLLOWUP_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip private reusable workflow

--- a/.github/workflows/notify-docs-preview.yml
+++ b/.github/workflows/notify-docs-preview.yml
@@ -11,17 +11,19 @@ jobs:
     name: Dispatch docs preview update
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Generate docs-center GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
+          repositories: wuji-docs-center
 
       - name: Dispatch docs preview event
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/notify-docs-preview.yml
+++ b/.github/workflows/notify-docs-preview.yml
@@ -1,4 +1,4 @@
-name: Notify Docs Preview
+name: Dispatch Docs Preview Update
 
 on:
   pull_request:
@@ -7,11 +7,12 @@ on:
       - 'docs/external/**'
 
 jobs:
-  notify:
+  dispatch-docs-preview:
+    name: Dispatch docs preview update
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
+      - name: Generate docs-center GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -19,7 +20,8 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
 
-      - uses: peter-evans/repository-dispatch@v4
+      - name: Dispatch docs preview event
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/notify-docs-preview.yml
+++ b/.github/workflows/notify-docs-preview.yml
@@ -11,19 +11,17 @@ jobs:
     name: Dispatch docs preview update
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Generate docs-center GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
-          repositories: wuji-docs-center
 
       - name: Dispatch docs preview event
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -2,7 +2,7 @@ name: Dispatch Docs Publish Update
 
 on:
   push:
-    branches: [main, master]
+    branches: [master]
     paths:
       - 'docs/external/**'
 
@@ -10,19 +10,17 @@ jobs:
   dispatch-docs-publish:
     name: Dispatch docs publish update
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Generate docs-center GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
-          repositories: wuji-docs-center
 
       - name: Dispatch docs publish event
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,4 +1,4 @@
-name: Notify Docs Center
+name: Dispatch Docs Publish Update
 
 on:
   push:
@@ -7,10 +7,11 @@ on:
       - 'docs/external/**'
 
 jobs:
-  notify:
+  dispatch-docs-publish:
+    name: Dispatch docs publish update
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
+      - name: Generate docs-center GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -18,7 +19,8 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
 
-      - uses: peter-evans/repository-dispatch@v4
+      - name: Dispatch docs publish event
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -2,7 +2,7 @@ name: Dispatch Docs Publish Update
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
     paths:
       - 'docs/external/**'
 
@@ -10,17 +10,19 @@ jobs:
   dispatch-docs-publish:
     name: Dispatch docs publish update
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Generate docs-center GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
+          repositories: wuji-docs-center
 
       - name: Dispatch docs publish event
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: wuji-technology/wuji-docs-center

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ on:
                 description: "Version to release (e.g., 0.1.0 or 0.2.0-rc0)"
                 required: true
 
-permissions:
-    contents: read
-
 jobs:
     build-release-debs:
         name: Build Debian release packages (${{ matrix.ros_distro }}, ubuntu-${{ matrix.os_version }})
@@ -30,9 +27,8 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@v4
               with:
-                persist-credentials: false
                 fetch-depth: 0
                 submodules: recursive
 
@@ -89,7 +85,7 @@ jobs:
                   ./build_deb.sh "${ROS_DISTRO}" "${PACKAGE_VERSION}"
 
             - name: Upload Debian release package artifact
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
@@ -99,12 +95,10 @@ jobs:
         needs: build-release-debs
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
-        permissions:
-            contents: write
 
         steps:
             - name: Download Debian package artifacts
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@v4
               with:
                   path: artifacts
 
@@ -112,7 +106,7 @@ jobs:
               run: find artifacts -name "*.deb" -type f
 
             - name: Publish GitHub release
-              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+              uses: softprops/action-gh-release@v2
               with:
                   files: artifacts/**/*.deb
                   generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build and Publish Debian Release
 
 on:
     push:
@@ -11,7 +11,8 @@ on:
                 required: true
 
 jobs:
-    build-debs:
+    build-release-debs:
+        name: Build Debian release packages (${{ matrix.ros_distro }}, ubuntu-${{ matrix.os_version }})
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -25,17 +26,19 @@ jobs:
             image: ros:${{ matrix.ros_distro }}-ros-base
 
         steps:
-            - name: Checkout
+            - name: Checkout source
               uses: actions/checkout@v4
               with:
                 fetch-depth: 0
                 submodules: recursive
 
-            - name: Extract version
+            - name: Resolve release version
               id: version
+              env:
+                  INPUT_VERSION: ${{ github.event.inputs.version }}
               run: |
-                  if [ -n "${{ github.event.inputs.version }}" ]; then
-                    VERSION="${{ github.event.inputs.version }}"
+                  if [ -n "${INPUT_VERSION}" ]; then
+                    VERSION="${INPUT_VERSION}"
                   else
                     # Remove 'v' prefix from tag name
                     VERSION="${GITHUB_REF_NAME#v}"
@@ -43,7 +46,7 @@ jobs:
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
                   echo "Building version: ${VERSION}"
 
-            - name: Install dependencies
+            - name: Install Debian packaging dependencies
               run: |
                   apt-get update
                   apt-get install -y wget dpkg-dev
@@ -70,36 +73,40 @@ jobs:
                     ros-${{ matrix.ros_distro }}-std-msgs \
                     ros-${{ matrix.ros_distro }}-robot-state-publisher
 
-            - name: Build deb package
+            - name: Build Debian release package
+              env:
+                  ROS_DISTRO: ${{ matrix.ros_distro }}
+                  PACKAGE_VERSION: ${{ steps.version.outputs.version }}
               run: |
                   # Fix git dubious ownership error in CI
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
                   chmod +x build_deb.sh
-                  ./build_deb.sh ${{ matrix.ros_distro }} ${{ steps.version.outputs.version }}
+                  ./build_deb.sh "${ROS_DISTRO}" "${PACKAGE_VERSION}"
 
-            - name: Upload artifact
+            - name: Upload Debian release package artifact
               uses: actions/upload-artifact@v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
 
-    release:
-        needs: build-debs
+    publish-github-release:
+        name: Publish GitHub release
+        needs: build-release-debs
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
 
         steps:
-            - name: Download all artifacts
+            - name: Download Debian package artifacts
               uses: actions/download-artifact@v4
               with:
                   path: artifacts
 
-            - name: List artifacts
+            - name: List Debian package artifacts
               run: find artifacts -name "*.deb" -type f
 
-            - name: Create Release
-              uses: softprops/action-gh-release@v1
+            - name: Publish GitHub release
+              uses: softprops/action-gh-release@v2
               with:
                   files: artifacts/**/*.deb
                   generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
                 description: "Version to release (e.g., 0.1.0 or 0.2.0-rc0)"
                 required: true
 
+permissions:
+    contents: read
+
 jobs:
     build-release-debs:
         name: Build Debian release packages (${{ matrix.ros_distro }}, ubuntu-${{ matrix.os_version }})
@@ -27,8 +30,9 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
+                persist-credentials: false
                 fetch-depth: 0
                 submodules: recursive
 
@@ -85,7 +89,7 @@ jobs:
                   ./build_deb.sh "${ROS_DISTRO}" "${PACKAGE_VERSION}"
 
             - name: Upload Debian release package artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: ros-${{ matrix.ros_distro }}-wujihand-deb
                   path: ros-${{ matrix.ros_distro }}-wujihand_*.deb
@@ -95,10 +99,12 @@ jobs:
         needs: build-release-debs
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+            contents: write
 
         steps:
             - name: Download Debian package artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
                   path: artifacts
 
@@ -106,7 +112,7 @@ jobs:
               run: find artifacts -name "*.deb" -type f
 
             - name: Publish GitHub release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
               with:
                   files: artifacts/**/*.deb
                   generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,9 @@ jobs:
 
             - name: Resolve release version
               id: version
-              env:
-                  INPUT_VERSION: ${{ github.event.inputs.version }}
               run: |
-                  if [ -n "${INPUT_VERSION}" ]; then
-                    VERSION="${INPUT_VERSION}"
+                  if [ -n "${{ github.event.inputs.version }}" ]; then
+                    VERSION="${{ github.event.inputs.version }}"
                   else
                     # Remove 'v' prefix from tag name
                     VERSION="${GITHUB_REF_NAME#v}"
@@ -74,15 +72,12 @@ jobs:
                     ros-${{ matrix.ros_distro }}-robot-state-publisher
 
             - name: Build Debian release package
-              env:
-                  ROS_DISTRO: ${{ matrix.ros_distro }}
-                  PACKAGE_VERSION: ${{ steps.version.outputs.version }}
               run: |
                   # Fix git dubious ownership error in CI
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
                   chmod +x build_deb.sh
-                  ./build_deb.sh "${ROS_DISTRO}" "${PACKAGE_VERSION}"
+                  ./build_deb.sh ${{ matrix.ros_distro }} ${{ steps.version.outputs.version }}
 
             - name: Upload Debian release package artifact
               uses: actions/upload-artifact@v4
@@ -106,7 +101,7 @@ jobs:
               run: find artifacts -name "*.deb" -type f
 
             - name: Publish GitHub release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v1
               with:
                   files: artifacts/**/*.deb
                   generate_release_notes: true

--- a/wujihand_driver/src/wujihand_driver_node.cpp
+++ b/wujihand_driver/src/wujihand_driver_node.cpp
@@ -154,10 +154,14 @@ bool WujiHandDriverNode::connect_hardware() {
     // Update ROS parameters with hardware info so other nodes can query them
     this->set_parameter(rclcpp::Parameter("handedness", handedness_));
     this->set_parameter(rclcpp::Parameter("firmware_version", firmware_version_));
-    this->set_parameter(rclcpp::Parameter("joint_upper_limits",
-        std::vector<double>(joint_upper_limits_.begin(), joint_upper_limits_.end())));
-    this->set_parameter(rclcpp::Parameter("joint_lower_limits",
-        std::vector<double>(joint_lower_limits_.begin(), joint_lower_limits_.end())));
+    this->set_parameter(
+        rclcpp::Parameter("joint_upper_limits",
+                          std::vector<double>(joint_upper_limits_.begin(),
+                                              joint_upper_limits_.end())));
+    this->set_parameter(
+        rclcpp::Parameter("joint_lower_limits",
+                          std::vector<double>(joint_lower_limits_.begin(),
+                                              joint_lower_limits_.end())));
 
     hardware_connected_ = true;
     RCLCPP_INFO(this->get_logger(), "Connected to WujiHand (%s)", handedness_.c_str());

--- a/wujihand_driver/src/wujihand_driver_node.cpp
+++ b/wujihand_driver/src/wujihand_driver_node.cpp
@@ -154,14 +154,12 @@ bool WujiHandDriverNode::connect_hardware() {
     // Update ROS parameters with hardware info so other nodes can query them
     this->set_parameter(rclcpp::Parameter("handedness", handedness_));
     this->set_parameter(rclcpp::Parameter("firmware_version", firmware_version_));
-    this->set_parameter(
-        rclcpp::Parameter("joint_upper_limits",
-                          std::vector<double>(joint_upper_limits_.begin(),
-                                              joint_upper_limits_.end())));
-    this->set_parameter(
-        rclcpp::Parameter("joint_lower_limits",
-                          std::vector<double>(joint_lower_limits_.begin(),
-                                              joint_lower_limits_.end())));
+    this->set_parameter(rclcpp::Parameter(
+        "joint_upper_limits",
+        std::vector<double>(joint_upper_limits_.begin(), joint_upper_limits_.end())));
+    this->set_parameter(rclcpp::Parameter(
+        "joint_lower_limits",
+        std::vector<double>(joint_lower_limits_.begin(), joint_lower_limits_.end())));
 
     hardware_connected_ = true;
     RCLCPP_INFO(this->get_logger(), "Connected to WujiHand (%s)", handedness_.c_str());


### PR DESCRIPTION
## Summary
- rename GitHub Actions workflows, jobs, and check runs so validation, release, and docs automation each describe their responsibility
- make the validation workflow explicit: ROS workspace build, Debian package build, C++ format check, and a required validation gate
- keep public docs follow-up workflows as clearly disabled placeholders instead of private reusable workflow callers
- keep the current CI fixes for pull_request packaging validation, strict clang-format checking, and public workflow compatibility

## Test Plan
- `/tmp/wujihandros2-tools/actionlint .github/workflows/*.yml`
- `git diff --check`
- `find . \( -name "*.cpp" -o -name "*.hpp" \) -print0 | xargs -0 -r clang-format --dry-run --Werror`

## Feishu Work Item
- Not assigned; this is a CI remediation PR from fork `main` because branch creation is blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 重命名并重构多条 CI 工作流，校验聚合更严格，控制合并通过逻辑更清晰
  * Debian 包构建触发范围扩大至 PR/手动触发，构建产物会随工作流上传并用于发布
  * 多个发布/通知工作流与任务展示名称更明确，派发流程增强

* **代码维护**
  * 全仓库 C++ 格式校验更严格；驱动节点仅做排版调整，不影响行为

* **文档**
  * Docs follow-up 在公开仓库场景下显式禁用并输出提示，避免调用私有工作流依赖
<!-- end of auto-generated comment: release notes by coderabbit.ai -->