### PR TITLE
feat: dual-hand launch (connect by handedness) and smooth homing

### DIFF
--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -51,17 +51,20 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 
 ### Launch Both Hands with One Command
 
-Auto-connect both hands without specifying serial numbers (left namespace `left_hand`, right `right_hand`):
+One command auto-discovers and connects every plugged-in hand — no serial numbers needed. Each hand is named by its detected handedness, publishing topics under `/hand_left/*` and `/hand_right/*`:
 
 ```bash
 ros2 launch wujihand_bringup wujihand_dual.launch.py
 ```
 
-To specify serial numbers or enable visualization:
+Optional visualization:
 
 ```bash
-ros2 launch wujihand_bringup wujihand_dual.launch.py \
-    left_serial_number:=ABC123 right_serial_number:=DEF456 rviz:=true
+# One RViz window per hand
+ros2 launch wujihand_bringup wujihand_dual.launch.py rviz:=true
+
+# A single Foxglove Bridge
+ros2 launch wujihand_bringup wujihand_dual.launch.py foxglove:=true
 ```
 
 ### Run Multi-hand Demos

--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -21,6 +21,7 @@ Handedness (left/right) is automatically detected from hardware. No manual speci
 | `hand_name` | `hand_0` | Namespace for distinguishing multiple hands. <br/> Example: `ros2 launch wujihand_bringup wujihand.launch.py hand_name:=my_hand` |
 | `serial_number` | `""` | Device serial number (auto-detect if empty) |
 | `hand_side` | `""` | Connect by handedness when no serial_number: `""` (unique device), `left`, `right` |
+| `name_by_handedness` | `false` | When true, roots topics and services under `/hand_<handedness>/`, overriding `hand_name`. Dual-hand launch enables this automatically |
 | `publish_rate` | `1000.0` | Joint state publishing rate (Hz) |
 | `filter_cutoff_freq` | `10.0` | Low-pass filter cutoff frequency (Hz) |
 | `diagnostics_rate` | `10.0` | Diagnostics publishing rate (Hz) |
@@ -29,6 +30,14 @@ Handedness (left/right) is automatically detected from hardware. No manual speci
 ## Multi-hand Configuration
 
 When controlling multiple dexterous hands simultaneously, use serial numbers and namespaces to distinguish them.
+
+### List Connected Device Serial Numbers
+
+List the serial numbers of all WujiHand devices currently on the USB bus, then plug them into the `serial_number` parameter in the launch commands below:
+
+```bash
+ros2 run wujihand_driver wujihand_list
+```
 
 If opening a new terminal, you need to source the ROS2 environment again
 ```bash

--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -8,6 +8,7 @@ title: Configuration
 |:--------|:------------|
 | `ros2 launch wujihand_bringup wujihand.launch.py` | Launch driver only |
 | `ros2 launch wujihand_bringup wujihand.launch.py rviz:=true` | Launch driver with RViz visualization |
+| `ros2 launch wujihand_bringup wujihand_dual.launch.py` | Launch and auto-connect both hands |
 
 ## Configurable Parameters
 
@@ -19,6 +20,7 @@ Handedness (left/right) is automatically detected from hardware. No manual speci
 |:----------|:--------|:------------|
 | `hand_name` | `hand_0` | Namespace for distinguishing multiple hands. <br/> Example: `ros2 launch wujihand_bringup wujihand.launch.py hand_name:=my_hand` |
 | `serial_number` | `""` | Device serial number (auto-detect if empty) |
+| `hand_side` | `""` | Connect by handedness when no serial_number: `""` (unique device), `left`, `right` |
 | `publish_rate` | `1000.0` | Joint state publishing rate (Hz) |
 | `filter_cutoff_freq` | `10.0` | Low-pass filter cutoff frequency (Hz) |
 | `diagnostics_rate` | `10.0` | Diagnostics publishing rate (Hz) |
@@ -45,6 +47,21 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 # Terminal 2: Launch right hand
 ros2 launch wujihand_bringup wujihand.launch.py \
     hand_name:=right_hand serial_number:=DEF456
+```
+
+### Launch Both Hands with One Command
+
+Auto-connect both hands without specifying serial numbers (left namespace `left_hand`, right `right_hand`):
+
+```bash
+ros2 launch wujihand_bringup wujihand_dual.launch.py
+```
+
+To specify serial numbers or enable visualization:
+
+```bash
+ros2 launch wujihand_bringup wujihand_dual.launch.py \
+    left_serial_number:=ABC123 right_serial_number:=DEF456 rviz:=true
 ```
 
 ### Run Multi-hand Demos

--- a/docs/external/en/ros2-interface.mdx
+++ b/docs/external/en/ros2-interface.mdx
@@ -122,6 +122,19 @@ ros2 topic pub /hand_0/joint_commands sensor_msgs/msg/JointState \
   "{name: ['right_finger2_joint2', 'right_finger2_joint3'], position: [1.0, 1.0]}" --once
 ```
 
+### Smooth Homing
+
+`home.launch.py` smoothly interpolates from the current pose back to zero, avoiding an abrupt snap:
+
+```bash
+# Home a single hand
+ros2 launch wujihand_bringup home.launch.py
+
+# Home both hands together over 1.5s
+ros2 launch wujihand_bringup home.launch.py \
+    hand_names:=left_hand,right_hand duration:=1.5
+```
+
 ### Read Joint States
 
 ```bash

--- a/docs/external/en/ros2-interface.mdx
+++ b/docs/external/en/ros2-interface.mdx
@@ -130,9 +130,9 @@ ros2 topic pub /hand_0/joint_commands sensor_msgs/msg/JointState \
 # Home a single hand
 ros2 launch wujihand_bringup home.launch.py
 
-# Home both hands together over 1.5s
+# Home both hands together over 1.5s (names match the topics wujihand_dual.launch.py publishes)
 ros2 launch wujihand_bringup home.launch.py \
-    hand_names:=left_hand,right_hand duration:=1.5
+    hand_names:=hand_left,hand_right duration:=1.5
 ```
 
 ### Read Joint States

--- a/docs/external/en/ros2-interface.mdx
+++ b/docs/external/en/ros2-interface.mdx
@@ -2,6 +2,10 @@
 title: ROS2 Interface
 ---
 
+<Callout type="info">
+The topic and service paths in the examples below use the default namespace `/hand_0/`. When launched with `wujihand_dual.launch.py`, topics and services live under `/hand_left/` and `/hand_right/` — replace `/hand_0/` accordingly.
+</Callout>
+
 ## Interface Reference
 
 ### HandDiagnostics Message
@@ -32,7 +36,7 @@ float32[20] effort_limits       # Effort limit settings (A)
 <Callout type="info">
 **About the Effort Field**
 
-Effort represents the actuator output in current space, filtered before output. It is not the actual measured current value; consider it as relative drive intensity.
+Effort represents the actuator output in current space, filtered before output. It is not the actual measured current value. Consider it as relative drive intensity.
 
 Typical use cases:
 - **Collision detection**: A sudden increase in effort indicates joint obstruction

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -21,6 +21,7 @@ title: 启动与配置
 | `hand_name` | `hand_0` | 命名空间，用于区分多手。 <br/> 示例：`ros2 launch wujihand_bringup wujihand.launch.py hand_name:=my_hand` |
 | `serial_number` | `""` | 设备序列号（空则自动检测） |
 | `hand_side` | `""` | 无序列号时按左右手连接：`""`（唯一设备）、`left`、`right` |
+| `name_by_handedness` | `false` | 开启后话题与服务根命名空间使用硬件检测到的左右手（`/hand_left/`、`/hand_right/`），覆盖 `hand_name`。双手启动会自动开启 |
 | `publish_rate` | `1000.0` | 关节状态发布频率 (Hz) |
 | `filter_cutoff_freq` | `10.0` | 低通滤波截止频率 (Hz) |
 | `diagnostics_rate` | `10.0` | 诊断信息发布频率 (Hz) |
@@ -29,6 +30,14 @@ title: 启动与配置
 ## 多手配置
 
 当需要同时控制多只灵巧手时，可通过序列号和命名空间区分。
+
+### 查询已连接设备的序列号
+
+列出当前 USB 上所有 WujiHand 设备的序列号，填入下方启动命令的 `serial_number`：
+
+```bash
+ros2 run wujihand_driver wujihand_list
+```
 
 如果打开新终端，需要重新加载 ROS2 环境
 ```bash

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -51,17 +51,20 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 
 ### 一键启动双手
 
-无需手动指定序列号，一条命令自动连接左右手（左手 namespace `left_hand`，右手 `right_hand`）：
+一条命令自动发现并连接所有已插入的手，无需手动指定序列号。每只手按硬件检测到的左右手，话题发布在 `/hand_left/*` 与 `/hand_right/*`：
 
 ```bash
 ros2 launch wujihand_bringup wujihand_dual.launch.py
 ```
 
-如需指定序列号或开启可视化：
+可选可视化：
 
 ```bash
-ros2 launch wujihand_bringup wujihand_dual.launch.py \
-    left_serial_number:=ABC123 right_serial_number:=DEF456 rviz:=true
+# 每只手一个 RViz 窗口
+ros2 launch wujihand_bringup wujihand_dual.launch.py rviz:=true
+
+# 单个 Foxglove Bridge
+ros2 launch wujihand_bringup wujihand_dual.launch.py foxglove:=true
 ```
 
 ### 运行多手演示

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -8,6 +8,7 @@ title: 启动与配置
 |:-----|:-----|
 | `ros2 launch wujihand_bringup wujihand.launch.py` | 仅启动驱动 |
 | `ros2 launch wujihand_bringup wujihand.launch.py rviz:=true` | 启动驱动并通过 RViz 可视化 |
+| `ros2 launch wujihand_bringup wujihand_dual.launch.py` | 一键启动并自动连接左右两只手 |
 
 ## 可配置参数
 
@@ -19,6 +20,7 @@ title: 启动与配置
 |:-----|:-------|:-----|
 | `hand_name` | `hand_0` | 命名空间，用于区分多手。 <br/> 示例：`ros2 launch wujihand_bringup wujihand.launch.py hand_name:=my_hand` |
 | `serial_number` | `""` | 设备序列号（空则自动检测） |
+| `hand_side` | `""` | 无序列号时按左右手连接：`""`（唯一设备）、`left`、`right` |
 | `publish_rate` | `1000.0` | 关节状态发布频率 (Hz) |
 | `filter_cutoff_freq` | `10.0` | 低通滤波截止频率 (Hz) |
 | `diagnostics_rate` | `10.0` | 诊断信息发布频率 (Hz) |
@@ -45,6 +47,21 @@ ros2 launch wujihand_bringup wujihand.launch.py \
 # 终端 2：启动右手
 ros2 launch wujihand_bringup wujihand.launch.py \
     hand_name:=right_hand serial_number:=DEF456
+```
+
+### 一键启动双手
+
+无需手动指定序列号，一条命令自动连接左右手（左手 namespace `left_hand`，右手 `right_hand`）：
+
+```bash
+ros2 launch wujihand_bringup wujihand_dual.launch.py
+```
+
+如需指定序列号或开启可视化：
+
+```bash
+ros2 launch wujihand_bringup wujihand_dual.launch.py \
+    left_serial_number:=ABC123 right_serial_number:=DEF456 rviz:=true
 ```
 
 ### 运行多手演示

--- a/docs/external/zh/ros2-interface.mdx
+++ b/docs/external/zh/ros2-interface.mdx
@@ -122,6 +122,19 @@ ros2 topic pub /hand_0/joint_commands sensor_msgs/msg/JointState \
   "{name: ['right_finger2_joint2', 'right_finger2_joint3'], position: [1.0, 1.0]}" --once
 ```
 
+### 平滑回零
+
+`home.launch.py` 从当前位置平滑插值回零，避免猛然弹回：
+
+```bash
+# 单手回零
+ros2 launch wujihand_bringup home.launch.py
+
+# 双手一起回零，1.5s 完成
+ros2 launch wujihand_bringup home.launch.py \
+    hand_names:=left_hand,right_hand duration:=1.5
+```
+
 ### 读取关节状态
 
 ```bash

--- a/docs/external/zh/ros2-interface.mdx
+++ b/docs/external/zh/ros2-interface.mdx
@@ -2,6 +2,10 @@
 title: ROS2 接口
 ---
 
+<Callout type="info">
+以下示例的话题与服务路径均使用默认命名空间 `/hand_0/`。使用 `wujihand_dual.launch.py` 启动时，话题与服务在 `/hand_left/` 和 `/hand_right/` 下，请按需替换 `/hand_0/`。
+</Callout>
+
 ## 接口清单
 
 ### HandDiagnostics 消息

--- a/docs/external/zh/ros2-interface.mdx
+++ b/docs/external/zh/ros2-interface.mdx
@@ -130,9 +130,9 @@ ros2 topic pub /hand_0/joint_commands sensor_msgs/msg/JointState \
 # 单手回零
 ros2 launch wujihand_bringup home.launch.py
 
-# 双手一起回零，1.5s 完成
+# 双手一起回零，1.5s 完成（名字与 wujihand_dual.launch.py 发布的话题一致）
 ros2 launch wujihand_bringup home.launch.py \
-    hand_names:=left_hand,right_hand duration:=1.5
+    hand_names:=hand_left,hand_right duration:=1.5
 ```
 
 ### 读取关节状态

--- a/wujihand_bringup/CMakeLists.txt
+++ b/wujihand_bringup/CMakeLists.txt
@@ -10,6 +10,7 @@ install(DIRECTORY launch
 
 install(PROGRAMS
   scripts/wave_demo.py
+  scripts/home.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/wujihand_bringup/launch/common.py
+++ b/wujihand_bringup/launch/common.py
@@ -1,10 +1,11 @@
 """Common launch utilities for WujiHand."""
 
 import os
+import subprocess
 import time
 
 import rclpy
-from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import get_package_prefix, get_package_share_directory
 from launch import logging
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -73,11 +74,49 @@ def detect_handedness(hand_name, timeout_sec=15):
     return hand_type
 
 
+def make_robot_state_publisher(hand_type, namespace):
+    """Build a robot_state_publisher Node for the given handedness, in a namespace.
+
+    Args:
+        hand_type: "left" or "right" (selects the URDF)
+        namespace: namespace to place the robot_state_publisher in (its
+            joint_states/robot_description/tf live here)
+
+    Returns:
+        robot_state_publisher Node, or None if the URDF cannot be read
+    """
+    wuji_description_dir = get_package_share_directory("wuji_description")
+    urdf_file = os.path.join(wuji_description_dir, "urdf", f"{hand_type}-ros.urdf")
+    try:
+        with open(urdf_file, "r") as f:
+            robot_description = f.read()
+    except OSError as e:
+        _logger.error(f"Failed to read URDF file: {e}")
+        return None
+
+    # Note: robot_state_publisher subscribes to joint_states with SensorDataQoS by default
+    return Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        namespace=namespace,
+        parameters=[
+            {"robot_description": ParameterValue(robot_description, value_type=str)},
+            {"publish_frequency": 100.0},
+        ],
+        remappings=[
+            ("joint_states", "joint_states"),
+        ],
+        output="screen",
+    )
+
+
 def spawn_robot_state_publisher(context):
     """Spawn robot_state_publisher after detecting handedness from driver.
 
     This function polls the driver node for the handedness parameter,
-    then creates a robot_state_publisher with the appropriate URDF.
+    then creates a robot_state_publisher with the appropriate URDF in the
+    same namespace as the driver (single-hand layout).
 
     Args:
         context: Launch context
@@ -86,7 +125,6 @@ def spawn_robot_state_publisher(context):
         List containing robot_state_publisher Node, or empty list on failure
     """
     hand_name = LaunchConfiguration("hand_name").perform(context)
-    wuji_description_dir = get_package_share_directory("wuji_description")
 
     # Detect handedness from driver node
     hand_type = detect_handedness(hand_name)
@@ -98,39 +136,33 @@ def spawn_robot_state_publisher(context):
 
     _logger.info(f"Using handedness: {hand_type}")
 
-    # Read the pre-generated ROS URDF file
-    urdf_file = os.path.join(
-        wuji_description_dir, "urdf", f"{hand_type}-ros.urdf"
+    node = make_robot_state_publisher(hand_type, hand_name)
+    return [node] if node is not None else []
+
+
+def list_serial_numbers():
+    """Return USB serial numbers of all connected WujiHand devices.
+
+    Shells out to the wujihand_list tool (in the wujihand_driver package), which
+    enumerates devices without claiming the USB interface, so it never collides
+    with a running driver. Returns an empty list on failure.
+    """
+    tool = os.path.join(
+        get_package_prefix("wujihand_driver"), "lib", "wujihand_driver", "wujihand_list"
     )
     try:
-        with open(urdf_file, "r") as f:
-            robot_description = f.read()
-    except OSError as e:
-        _logger.error(f"Failed to read URDF file: {e}")
+        result = subprocess.run(
+            [tool], capture_output=True, text=True, timeout=10.0, check=False
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        _logger.error(f"Failed to run wujihand_list ({tool}): {e}")
         return []
 
-    # Return robot_state_publisher node with URDF string as parameter
-    # Note: robot_state_publisher subscribes to joint_states with SensorDataQoS by default
-    return [
-        Node(
-            package="robot_state_publisher",
-            executable="robot_state_publisher",
-            name="robot_state_publisher",
-            namespace=hand_name,
-            parameters=[
-                {
-                    "robot_description": ParameterValue(
-                        robot_description, value_type=str
-                    )
-                },
-                {"publish_frequency": 100.0},
-            ],
-            remappings=[
-                ("joint_states", "joint_states"),
-            ],
-            output="screen",
-        )
-    ]
+    if result.returncode != 0:
+        _logger.error(f"wujihand_list failed: {result.stderr.strip()}")
+        return []
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def get_common_launch_arguments():

--- a/wujihand_bringup/launch/home.launch.py
+++ b/wujihand_bringup/launch/home.launch.py
@@ -1,7 +1,10 @@
 from launch import LaunchDescription
+from launch import logging
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+
+_logger = logging.get_logger("home")
 
 
 def parse_hand_names(raw):
@@ -12,8 +15,12 @@ def parse_hand_names(raw):
 def spawn_home_nodes(context):
     """Spawn one home.py node per hand name in hand_names."""
     raw = LaunchConfiguration("hand_names").perform(context)
-    duration = float(LaunchConfiguration("duration").perform(context))
-    rate = float(LaunchConfiguration("rate").perform(context))
+    try:
+        duration = float(LaunchConfiguration("duration").perform(context))
+        rate = float(LaunchConfiguration("rate").perform(context))
+    except ValueError as exc:
+        _logger.error(f"duration and rate must be numbers: {exc}")
+        return []
 
     nodes = []
     for name in parse_hand_names(raw):

--- a/wujihand_bringup/launch/home.launch.py
+++ b/wujihand_bringup/launch/home.launch.py
@@ -1,0 +1,49 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def parse_hand_names(raw):
+    """Split a comma-separated hand_names string into a clean, non-empty list."""
+    return [name.strip() for name in raw.split(",") if name.strip()]
+
+
+def spawn_home_nodes(context):
+    """Spawn one home.py node per hand name in hand_names."""
+    raw = LaunchConfiguration("hand_names").perform(context)
+    duration = float(LaunchConfiguration("duration").perform(context))
+    rate = float(LaunchConfiguration("rate").perform(context))
+
+    nodes = []
+    for name in parse_hand_names(raw):
+        nodes.append(
+            Node(
+                package="wujihand_bringup",
+                executable="home.py",
+                name=f"home_{name}",
+                parameters=[{"hand_name": name, "duration": duration, "rate": rate}],
+                output="screen",
+                emulate_tty=True,
+            )
+        )
+    return nodes
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "hand_names",
+                default_value="hand_0",
+                description="Comma-separated hand namespaces, e.g. left_hand,right_hand",
+            ),
+            DeclareLaunchArgument(
+                "duration", default_value="2.0", description="Homing duration in seconds"
+            ),
+            DeclareLaunchArgument(
+                "rate", default_value="100.0", description="Command publish rate in Hz"
+            ),
+            OpaqueFunction(function=spawn_home_nodes),
+        ]
+    )

--- a/wujihand_bringup/launch/wujihand.launch.py
+++ b/wujihand_bringup/launch/wujihand.launch.py
@@ -52,6 +52,12 @@ def generate_launch_description():
         description="Serial number of the WujiHand device",
     )
 
+    hand_side_arg = DeclareLaunchArgument(
+        "hand_side",
+        default_value="",
+        description="Connect by handedness when no serial_number: '' (unique device), 'left', 'right'",
+    )
+
     publish_rate_arg = DeclareLaunchArgument(
         "publish_rate", default_value="1000.0", description="State publish rate in Hz"
     )
@@ -84,6 +90,9 @@ def generate_launch_description():
     serial_number_str = ParameterValue(
         LaunchConfiguration("serial_number"), value_type=str
     )
+    hand_side_str = ParameterValue(
+        LaunchConfiguration("hand_side"), value_type=str
+    )
 
     wujihand_driver_node = Node(
         package="wujihand_driver",
@@ -93,6 +102,7 @@ def generate_launch_description():
         parameters=[
             {
                 "serial_number": serial_number_str,
+                "hand_side": hand_side_str,
                 "publish_rate": LaunchConfiguration("publish_rate"),
                 "filter_cutoff_freq": LaunchConfiguration("filter_cutoff_freq"),
                 "diagnostics_rate": LaunchConfiguration("diagnostics_rate"),
@@ -130,6 +140,7 @@ def generate_launch_description():
         [
             hand_name_arg,
             serial_number_arg,
+            hand_side_arg,
             publish_rate_arg,
             filter_cutoff_freq_arg,
             diagnostics_rate_arg,

--- a/wujihand_bringup/launch/wujihand_dual.launch.py
+++ b/wujihand_bringup/launch/wujihand_dual.launch.py
@@ -1,0 +1,67 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    """Launch both hands by including the single-hand launch twice.
+
+    Left hand connects via hand_side='left', right via 'right'. A serial_number
+    override (when provided) takes precedence over hand_side in the driver.
+    """
+    single_launch = os.path.join(
+        get_package_share_directory("wujihand_bringup"), "launch", "wujihand.launch.py"
+    )
+
+    args = [
+        DeclareLaunchArgument(
+            "left_hand_name", default_value="left_hand", description="Left hand namespace"
+        ),
+        DeclareLaunchArgument(
+            "right_hand_name", default_value="right_hand", description="Right hand namespace"
+        ),
+        DeclareLaunchArgument(
+            "left_serial_number",
+            default_value="",
+            description="Left hand serial number (overrides hand_side when set)",
+        ),
+        DeclareLaunchArgument(
+            "right_serial_number",
+            default_value="",
+            description="Right hand serial number (overrides hand_side when set)",
+        ),
+        DeclareLaunchArgument(
+            "rviz", default_value="false", description="Launch RViz for both hands"
+        ),
+        DeclareLaunchArgument(
+            "foxglove", default_value="false", description="Launch Foxglove Bridge for both hands"
+        ),
+    ]
+
+    left_hand = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(single_launch),
+        launch_arguments={
+            "hand_name": LaunchConfiguration("left_hand_name"),
+            "hand_side": "left",
+            "serial_number": LaunchConfiguration("left_serial_number"),
+            "rviz": LaunchConfiguration("rviz"),
+            "foxglove": LaunchConfiguration("foxglove"),
+        }.items(),
+    )
+
+    right_hand = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(single_launch),
+        launch_arguments={
+            "hand_name": LaunchConfiguration("right_hand_name"),
+            "hand_side": "right",
+            "serial_number": LaunchConfiguration("right_serial_number"),
+            "rviz": LaunchConfiguration("rviz"),
+            "foxglove": LaunchConfiguration("foxglove"),
+        }.items(),
+    )
+
+    return LaunchDescription(args + [left_hand, right_hand])

--- a/wujihand_bringup/launch/wujihand_dual.launch.py
+++ b/wujihand_bringup/launch/wujihand_dual.launch.py
@@ -1,67 +1,126 @@
 import os
+import sys
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch import logging
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, TimerAction
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+# Add launch directory to path for local imports
+sys.path.insert(0, os.path.dirname(__file__))
+from common import detect_handedness, list_serial_numbers, make_robot_state_publisher
+
+_logger = logging.get_logger("wujihand_dual")
+
+
+def _spawn_description(node_hand_name, want_rviz):
+    """Build an OpaqueFunction that, once the driver is up, detects its handedness
+    and spawns robot_state_publisher (and optionally RViz) under /hand_<handedness>,
+    matching the driver's handedness-named topics."""
+
+    def _fn(context):
+        hand_type = detect_handedness(node_hand_name)
+        if hand_type is None:
+            _logger.error(f"Could not detect handedness for {node_hand_name}; skipping RViz/URDF.")
+            return []
+
+        namespace = f"hand_{hand_type}"
+        actions = []
+        rsp = make_robot_state_publisher(hand_type, namespace)
+        if rsp is not None:
+            actions.append(rsp)
+
+        if want_rviz:
+            rviz_config = os.path.join(
+                get_package_share_directory("wuji_description"), "rviz", f"{hand_type}.rviz"
+            )
+            actions.append(
+                Node(
+                    package="rviz2",
+                    executable="rviz2",
+                    name="rviz2",
+                    namespace=namespace,
+                    arguments=["-d", rviz_config],
+                    output="screen",
+                )
+            )
+        return actions
+
+    return _fn
+
+
+def spawn_dual_hands(context):
+    """Discover connected devices by serial number and start one driver per device.
+
+    Discovery (wujihand_list) only reads USB serial descriptors, and each driver
+    connects by its own serial number, so two drivers never race on the USB claim.
+    Each driver self-detects its handedness and publishes topics under
+    /hand_<handedness>; the node itself stays under a generic hand_<index> namespace.
+    """
+    serial_numbers = list_serial_numbers()
+    if not serial_numbers:
+        _logger.error("No WujiHand devices found. Is the hardware connected?")
+        return []
+
+    _logger.info(f"Discovered {len(serial_numbers)} device(s): {', '.join(serial_numbers)}")
+    want_rviz = LaunchConfiguration("rviz").perform(context).lower() in ("true", "1")
+
+    actions = []
+    for idx, serial_number in enumerate(serial_numbers):
+        node_hand_name = f"hand_{idx}"
+        actions.append(
+            Node(
+                package="wujihand_driver",
+                executable="wujihand_driver_node",
+                name="wujihand_driver",
+                namespace=node_hand_name,
+                parameters=[{"serial_number": serial_number, "name_by_handedness": True}],
+                output="screen",
+                emulate_tty=True,
+            )
+        )
+        # Wait for the driver to connect and publish its handedness, then spawn
+        # robot_state_publisher (and optional RViz) under /hand_<handedness>.
+        actions.append(
+            TimerAction(
+                period=2.0,
+                actions=[OpaqueFunction(function=_spawn_description(node_hand_name, want_rviz))],
+            )
+        )
+    return actions
 
 
 def generate_launch_description():
-    """Launch both hands by including the single-hand launch twice.
-
-    Left hand connects via hand_side='left', right via 'right'. A serial_number
-    override (when provided) takes precedence over hand_side in the driver.
-    """
-    single_launch = os.path.join(
-        get_package_share_directory("wujihand_bringup"), "launch", "wujihand.launch.py"
+    rviz_arg = DeclareLaunchArgument(
+        "rviz",
+        default_value="false",
+        description="Whether to launch RViz (one window per hand)",
     )
 
-    args = [
-        DeclareLaunchArgument(
-            "left_hand_name", default_value="left_hand", description="Left hand namespace"
-        ),
-        DeclareLaunchArgument(
-            "right_hand_name", default_value="right_hand", description="Right hand namespace"
-        ),
-        DeclareLaunchArgument(
-            "left_serial_number",
-            default_value="",
-            description="Left hand serial number (overrides hand_side when set)",
-        ),
-        DeclareLaunchArgument(
-            "right_serial_number",
-            default_value="",
-            description="Right hand serial number (overrides hand_side when set)",
-        ),
-        DeclareLaunchArgument(
-            "rviz", default_value="false", description="Launch RViz for both hands"
-        ),
-        DeclareLaunchArgument(
-            "foxglove", default_value="false", description="Launch Foxglove Bridge for both hands"
-        ),
-    ]
-
-    left_hand = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(single_launch),
-        launch_arguments={
-            "hand_name": LaunchConfiguration("left_hand_name"),
-            "hand_side": "left",
-            "serial_number": LaunchConfiguration("left_serial_number"),
-            "rviz": LaunchConfiguration("rviz"),
-            "foxglove": LaunchConfiguration("foxglove"),
-        }.items(),
+    foxglove_arg = DeclareLaunchArgument(
+        "foxglove",
+        default_value="false",
+        description="Whether to launch a single Foxglove Bridge for web visualization",
     )
 
-    right_hand = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(single_launch),
-        launch_arguments={
-            "hand_name": LaunchConfiguration("right_hand_name"),
-            "hand_side": "right",
-            "serial_number": LaunchConfiguration("right_serial_number"),
-            "rviz": LaunchConfiguration("rviz"),
-            "foxglove": LaunchConfiguration("foxglove"),
-        }.items(),
+    # One Foxglove Bridge bridges all topics for both hands (avoids a port clash
+    # that two per-hand bridges would hit on the default 8765).
+    foxglove_bridge_node = Node(
+        package="foxglove_bridge",
+        executable="foxglove_bridge",
+        name="foxglove_bridge",
+        output="screen",
+        condition=IfCondition(LaunchConfiguration("foxglove")),
     )
 
-    return LaunchDescription(args + [left_hand, right_hand])
+    return LaunchDescription(
+        [
+            rviz_arg,
+            foxglove_arg,
+            OpaqueFunction(function=spawn_dual_hands),
+            foxglove_bridge_node,
+        ]
+    )

--- a/wujihand_bringup/scripts/home.py
+++ b/wujihand_bringup/scripts/home.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""WujiHand homing: smoothly interpolate every joint to zero, then exit.
+
+Usage:
+  ros2 run wujihand_bringup home.py
+  ros2 run wujihand_bringup home.py --ros-args -p hand_name:=left_hand -p duration:=1.5
+"""
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from rclpy.task import Future
+from sensor_msgs.msg import JointState
+
+NUM_JOINTS = 20
+
+
+def interpolate(start, t):
+    """Linear interpolation from start positions toward zero. t clamped to [0, 1]."""
+    t = max(0.0, min(1.0, t))
+    return [p * (1.0 - t) for p in start]
+
+
+class HomeNode(Node):
+    def __init__(self):
+        super().__init__("home")
+
+        self.declare_parameter("hand_name", "hand_0")
+        self.declare_parameter("duration", 2.0)
+        self.declare_parameter("rate", 100.0)
+        self.declare_parameter("timeout", 5.0)
+
+        hand_name = self.get_parameter("hand_name").get_parameter_value().string_value
+        self.duration = self.get_parameter("duration").get_parameter_value().double_value
+        self.rate = self.get_parameter("rate").get_parameter_value().double_value
+        timeout = self.get_parameter("timeout").get_parameter_value().double_value
+
+        self.start = None
+        self.start_time = None
+        self.done_future = Future()
+
+        self.cmd_pub = self.create_publisher(
+            JointState, f"/{hand_name}/joint_commands", qos_profile_sensor_data
+        )
+        self.state_sub = self.create_subscription(
+            JointState, f"/{hand_name}/joint_states", self._on_state, qos_profile_sensor_data
+        )
+
+        self.deadline = self.get_clock().now() + Duration(seconds=timeout)
+        self.timer = self.create_timer(1.0 / self.rate, self._on_timer)
+        self.get_logger().info(
+            f"Homing {hand_name} over {self.duration:.1f}s; waiting for joint_states..."
+        )
+
+    def _on_state(self, msg):
+        if self.start is None and len(msg.position) >= NUM_JOINTS:
+            self.start = list(msg.position[:NUM_JOINTS])
+            self.start_time = self.get_clock().now()
+            self.get_logger().info("Got initial positions; moving to zero.")
+
+    def _on_timer(self):
+        if self.done_future.done():
+            return
+
+        now = self.get_clock().now()
+        if self.start is None:
+            if now >= self.deadline:
+                self.get_logger().error(
+                    "No joint_states before timeout; is the driver running?"
+                )
+                self.done_future.set_result(False)
+            return
+
+        elapsed = (now - self.start_time).nanoseconds / 1e9
+        t = 1.0 if self.duration <= 0.0 else elapsed / self.duration
+
+        msg = JointState()
+        msg.position = interpolate(self.start, t)
+        self.cmd_pub.publish(msg)
+
+        if t >= 1.0:
+            self.get_logger().info("Reached zero pose; exiting.")
+            self.done_future.set_result(True)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = HomeNode()
+    try:
+        rclpy.spin_until_future_complete(node, node.done_future)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/wujihand_bringup/scripts/home.py
+++ b/wujihand_bringup/scripts/home.py
@@ -36,6 +36,17 @@ class HomeNode(Node):
         self.rate = self.get_parameter("rate").get_parameter_value().double_value
         timeout = self.get_parameter("timeout").get_parameter_value().double_value
 
+        # Validate numeric ranges (rate drives 1.0 / rate timers; guard div-by-zero).
+        if self.rate <= 0.0:
+            self.get_logger().warn(f"rate must be > 0; got {self.rate}, using 100.0")
+            self.rate = 100.0
+        if self.duration < 0.0:
+            self.get_logger().warn(f"duration must be >= 0; got {self.duration}, using 0.0")
+            self.duration = 0.0
+        if timeout <= 0.0:
+            self.get_logger().warn(f"timeout must be > 0; got {timeout}, using 5.0")
+            timeout = 5.0
+
         self.start = None
         self.start_time = None
         self.done_future = Future()

--- a/wujihand_driver/CMakeLists.txt
+++ b/wujihand_driver/CMakeLists.txt
@@ -69,8 +69,19 @@ target_link_libraries(wujihand_driver_node
   Threads::Threads
 )
 
+# Serial-number discovery tool (no ROS deps): prints connected WujiHand serial
+# numbers, used by the dual-hand launch to start one driver per device.
+add_executable(wujihand_list src/list_serial_numbers.cpp)
+target_include_directories(wujihand_list PRIVATE ${WUJIHANDCPP_INCLUDE_DIR})
+target_link_libraries(wujihand_list
+  ${WUJIHANDCPP_LIBRARY}
+  ${WUJIHANDCPP_SPDLOG_LIBRARY}
+  usb-1.0
+  Threads::Threads
+)
+
 # Install
-install(TARGETS wujihand_driver_node
+install(TARGETS wujihand_driver_node wujihand_list
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
+++ b/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
@@ -70,7 +70,8 @@ class WujiHandDriverNode : public rclcpp::Node {
 
   // Parameters
   std::string serial_number_;
-  std::string hand_side_;  // "" (unique device), "left" or "right"
+  std::string hand_side_;          // "" (unique device), "left" or "right"
+  bool name_by_handedness_{false}; // root topics at /hand_<handedness> when true
   double publish_rate_;
   double filter_cutoff_freq_;
   double diagnostics_rate_;

--- a/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
+++ b/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
@@ -70,6 +70,7 @@ class WujiHandDriverNode : public rclcpp::Node {
 
   // Parameters
   std::string serial_number_;
+  std::string hand_side_;  // "" (unique device), "left" or "right"
   double publish_rate_;
   double filter_cutoff_freq_;
   double diagnostics_rate_;

--- a/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
+++ b/wujihand_driver/include/wujihand_driver/wujihand_driver_node.hpp
@@ -70,8 +70,8 @@ class WujiHandDriverNode : public rclcpp::Node {
 
   // Parameters
   std::string serial_number_;
-  std::string hand_side_;          // "" (unique device), "left" or "right"
-  bool name_by_handedness_{false}; // root topics at /hand_<handedness> when true
+  std::string hand_side_;           // "" (unique device), "left" or "right"
+  bool name_by_handedness_{false};  // root topics at /hand_<handedness> when true
   double publish_rate_;
   double filter_cutoff_freq_;
   double diagnostics_rate_;

--- a/wujihand_driver/src/list_serial_numbers.cpp
+++ b/wujihand_driver/src/list_serial_numbers.cpp
@@ -1,0 +1,44 @@
+// Copyright 2025 Wuji Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Enumerate connected WujiHand serial numbers, one per line on stdout.
+//
+// Uses wujihandcpp's USB enumeration, which only opens devices to read the
+// serial-number descriptor (no libusb_claim_interface), so it never collides
+// with a running driver or another enumeration. The dual-hand launch shells
+// out to this tool to discover devices, then starts one driver per serial
+// number; connecting by serial only claims that one device, so two drivers
+// never race on libusb claim (LIBUSB_ERROR_BUSY).
+
+#include <cstdio>
+#include <exception>
+
+#include <wujihandcpp/transport/usb_enumerate.hpp>
+
+int main() {
+  // Default WujiHand USB identifiers (match wujihandcpp::device::Hand defaults).
+  constexpr uint16_t kUsbVid = 0x0483;
+  constexpr int32_t kUsbPid = 0x2000;
+
+  try {
+    const auto serial_numbers = wujihandcpp::transport::list_matching_serial_numbers(kUsbVid, kUsbPid);
+    for (const auto& sn : serial_numbers) {
+      std::printf("%s\n", sn.c_str());
+    }
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "Failed to list WujiHand serial numbers: %s\n", e.what());
+    return 1;
+  }
+  return 0;
+}

--- a/wujihand_driver/src/list_serial_numbers.cpp
+++ b/wujihand_driver/src/list_serial_numbers.cpp
@@ -23,7 +23,6 @@
 
 #include <cstdio>
 #include <exception>
-
 #include <wujihandcpp/transport/usb_enumerate.hpp>
 
 int main() {
@@ -32,7 +31,8 @@ int main() {
   constexpr int32_t kUsbPid = 0x2000;
 
   try {
-    const auto serial_numbers = wujihandcpp::transport::list_matching_serial_numbers(kUsbVid, kUsbPid);
+    const auto serial_numbers =
+        wujihandcpp::transport::list_matching_serial_numbers(kUsbVid, kUsbPid);
     for (const auto& sn : serial_numbers) {
       std::printf("%s\n", sn.c_str());
     }

--- a/wujihand_driver/src/wujihand_driver_node.cpp
+++ b/wujihand_driver/src/wujihand_driver_node.cpp
@@ -29,6 +29,7 @@ WujiHandDriverNode::WujiHandDriverNode() : Node("wujihand_driver"), hardware_con
   // Declare parameters
   this->declare_parameter("serial_number", "");
   this->declare_parameter("hand_side", "");
+  this->declare_parameter("name_by_handedness", false);
   this->declare_parameter("publish_rate", 1000.0);
   this->declare_parameter("filter_cutoff_freq", 10.0);
   this->declare_parameter("diagnostics_rate", 10.0);
@@ -36,6 +37,7 @@ WujiHandDriverNode::WujiHandDriverNode() : Node("wujihand_driver"), hardware_con
   // Get parameters
   serial_number_ = this->get_parameter("serial_number").as_string();
   hand_side_ = this->get_parameter("hand_side").as_string();
+  name_by_handedness_ = this->get_parameter("name_by_handedness").as_bool();
   publish_rate_ = this->get_parameter("publish_rate").as_double();
   filter_cutoff_freq_ = this->get_parameter("filter_cutoff_freq").as_double();
   diagnostics_rate_ = this->get_parameter("diagnostics_rate").as_double();
@@ -55,25 +57,32 @@ WujiHandDriverNode::WujiHandDriverNode() : Node("wujihand_driver"), hardware_con
     throw std::runtime_error("Hardware connection failed");
   }
 
+  // Interface name prefix. When name_by_handedness is set (multi-hand bringup,
+  // where the node namespace is a generic hand_0/hand_1), root all topics and
+  // services at the absolute /hand_<handedness>/ so the device's physical side
+  // names the interface. connect_hardware() ran above, so handedness_ is known.
+  // Otherwise use relative names under the node namespace (single-hand default).
+  const std::string prefix = name_by_handedness_ ? ("/hand_" + handedness_ + "/") : std::string();
+
   // Create publishers (use SensorDataQoS for compatibility with robot_state_publisher)
-  joint_state_pub_ =
-      this->create_publisher<sensor_msgs::msg::JointState>("joint_states", rclcpp::SensorDataQoS());
-  diagnostics_pub_ =
-      this->create_publisher<wujihand_msgs::msg::HandDiagnostics>("hand_diagnostics", 10);
+  joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
+      prefix + "joint_states", rclcpp::SensorDataQoS());
+  diagnostics_pub_ = this->create_publisher<wujihand_msgs::msg::HandDiagnostics>(
+      prefix + "hand_diagnostics", 10);
 
   // Create subscriber for joint commands (using SensorDataQoS for high-frequency data)
   cmd_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
-      "joint_commands", rclcpp::SensorDataQoS(),
+      prefix + "joint_commands", rclcpp::SensorDataQoS(),
       std::bind(&WujiHandDriverNode::command_callback, this, std::placeholders::_1));
 
   // Create services
   set_enabled_srv_ = this->create_service<wujihand_msgs::srv::SetEnabled>(
-      "set_enabled", std::bind(&WujiHandDriverNode::set_enabled_callback, this,
-                               std::placeholders::_1, std::placeholders::_2));
+      prefix + "set_enabled", std::bind(&WujiHandDriverNode::set_enabled_callback, this,
+                                        std::placeholders::_1, std::placeholders::_2));
 
   reset_error_srv_ = this->create_service<wujihand_msgs::srv::ResetError>(
-      "reset_error", std::bind(&WujiHandDriverNode::reset_error_callback, this,
-                               std::placeholders::_1, std::placeholders::_2));
+      prefix + "reset_error", std::bind(&WujiHandDriverNode::reset_error_callback, this,
+                                        std::placeholders::_1, std::placeholders::_2));
 
   // Initialize pre-allocated JointState message with handedness prefix
   joint_state_msg_.name.reserve(NUM_JOINTS);

--- a/wujihand_driver/src/wujihand_driver_node.cpp
+++ b/wujihand_driver/src/wujihand_driver_node.cpp
@@ -28,12 +28,14 @@ const std::array<std::string, WujiHandDriverNode::NUM_JOINTS> WujiHandDriverNode
 WujiHandDriverNode::WujiHandDriverNode() : Node("wujihand_driver"), hardware_connected_(false) {
   // Declare parameters
   this->declare_parameter("serial_number", "");
+  this->declare_parameter("hand_side", "");
   this->declare_parameter("publish_rate", 1000.0);
   this->declare_parameter("filter_cutoff_freq", 10.0);
   this->declare_parameter("diagnostics_rate", 10.0);
 
   // Get parameters
   serial_number_ = this->get_parameter("serial_number").as_string();
+  hand_side_ = this->get_parameter("hand_side").as_string();
   publish_rate_ = this->get_parameter("publish_rate").as_double();
   filter_cutoff_freq_ = this->get_parameter("filter_cutoff_freq").as_double();
   diagnostics_rate_ = this->get_parameter("diagnostics_rate").as_double();
@@ -103,8 +105,21 @@ WujiHandDriverNode::~WujiHandDriverNode() {
 
 bool WujiHandDriverNode::connect_hardware() {
   try {
-    const char* serial = serial_number_.empty() ? nullptr : serial_number_.c_str();
-    hand_ = std::make_unique<wujihandcpp::device::Hand>(serial);
+    // Connection precedence: serial_number > hand_side > unique device on bus.
+    using Side = wujihandcpp::device::Hand::Side;
+    if (!serial_number_.empty()) {
+      hand_ = std::make_unique<wujihandcpp::device::Hand>(serial_number_.c_str());
+    } else if (hand_side_ == "left") {
+      hand_ = std::make_unique<wujihandcpp::device::Hand>(Side::Left);
+    } else if (hand_side_ == "right") {
+      hand_ = std::make_unique<wujihandcpp::device::Hand>(Side::Right);
+    } else if (hand_side_.empty()) {
+      hand_ = std::make_unique<wujihandcpp::device::Hand>(nullptr);
+    } else {
+      RCLCPP_ERROR(this->get_logger(),
+                   "Invalid hand_side '%s' (expected '', 'left' or 'right')", hand_side_.c_str());
+      return false;
+    }
 
     // Create realtime controller with filter
     wujihandcpp::filter::LowPass filter(filter_cutoff_freq_);

--- a/wujihand_driver/src/wujihand_driver_node.cpp
+++ b/wujihand_driver/src/wujihand_driver_node.cpp
@@ -65,10 +65,10 @@ WujiHandDriverNode::WujiHandDriverNode() : Node("wujihand_driver"), hardware_con
   const std::string prefix = name_by_handedness_ ? ("/hand_" + handedness_ + "/") : std::string();
 
   // Create publishers (use SensorDataQoS for compatibility with robot_state_publisher)
-  joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
-      prefix + "joint_states", rclcpp::SensorDataQoS());
-  diagnostics_pub_ = this->create_publisher<wujihand_msgs::msg::HandDiagnostics>(
-      prefix + "hand_diagnostics", 10);
+  joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(prefix + "joint_states",
+                                                                          rclcpp::SensorDataQoS());
+  diagnostics_pub_ =
+      this->create_publisher<wujihand_msgs::msg::HandDiagnostics>(prefix + "hand_diagnostics", 10);
 
   // Create subscriber for joint commands (using SensorDataQoS for high-frequency data)
   cmd_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
@@ -125,8 +125,8 @@ bool WujiHandDriverNode::connect_hardware() {
     } else if (hand_side_.empty()) {
       hand_ = std::make_unique<wujihandcpp::device::Hand>(nullptr);
     } else {
-      RCLCPP_ERROR(this->get_logger(),
-                   "Invalid hand_side '%s' (expected '', 'left' or 'right')", hand_side_.c_str());
+      RCLCPP_ERROR(this->get_logger(), "Invalid hand_side '%s' (expected '', 'left' or 'right')",
+                   hand_side_.c_str());
       return false;
     }
 
@@ -178,9 +178,11 @@ bool WujiHandDriverNode::connect_hardware() {
     // Update ROS parameters with hardware info so other nodes can query them
     this->set_parameter(rclcpp::Parameter("handedness", handedness_));
     this->set_parameter(rclcpp::Parameter("firmware_version", firmware_version_));
-    this->set_parameter(rclcpp::Parameter("joint_upper_limits",
+    this->set_parameter(rclcpp::Parameter(
+        "joint_upper_limits",
         std::vector<double>(joint_upper_limits_.begin(), joint_upper_limits_.end())));
-    this->set_parameter(rclcpp::Parameter("joint_lower_limits",
+    this->set_parameter(rclcpp::Parameter(
+        "joint_lower_limits",
         std::vector<double>(joint_lower_limits_.begin(), joint_lower_limits_.end())));
 
     hardware_connected_ = true;


### PR DESCRIPTION
## Summary

Adds dual-hand bringup and smooth homing to `wujihand_bringup`, plus the driver
parameters they need.

- **Driver `hand_side` param**: when `serial_number` is empty, connect by handedness
  (`left`/`right`) via wujihandcpp `Hand(Side)`. Precedence: `serial_number` >
  `hand_side` > unique device. Single-hand convenience; existing behavior unchanged.
- **Driver `name_by_handedness` param**: when set, root topics/services at the absolute
  `/hand_<handedness>/` (e.g. `/hand_left/joint_states`) using the side detected at
  connect time, instead of the node namespace. Default off.
- **Single-hand launch**: forward `hand_side` through `wujihand.launch.py`.
- **Serial-number discovery** (`wujihand_list`): a small tool that lists connected device
  serial numbers via wujihandcpp (`list_matching_serial_numbers` — reads USB descriptors
  only, no `claim_interface`), used by the dual-hand launch.
- **Dual-hand launch** (`wujihand_dual.launch.py`): auto-discover every connected device,
  start one driver per device **by serial number** (so two drivers never race on the USB
  claim), each publishing under `/hand_left` / `/hand_right`; `robot_state_publisher` (and
  optional per-hand RViz) spawned by detected handedness; one shared Foxglove Bridge.
- **Smooth homing**: `home.py` interpolates every joint to zero over a configurable
  `duration` then exits; `home.launch.py` homes one or more hands
  (`hand_names:=hand_left,hand_right`).
- Install `home.py` and `wujihand_list`; document the above (zh + en).

## Test Plan
- `colcon build` (wujihand_msgs / wujihand_driver / wujihand_bringup) passes.
- `python3 -m py_compile` + `ros2 launch ... --show-args` for all three launch files.
- Pure-logic checks: `interpolate` (hold / halve / zero / clamp) and `parse_hand_names`.
- `wujihand_list` builds, installs, and runs.
- Hardware (single hand): driver connects (`Connected to WujiHand (right)`, 1000 Hz);
  smooth homing verified.
- ⚠️ To verify with hardware: dual-hand serial discovery + per-hand connect with two
  hands plugged in (requires devices to expose a USB serial-number descriptor).

## Related
Work item: m-7005928076

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 一键启动双手：自动发现并连接所有已插入设备，按左右手命名并支持 RViz/Foxglove 可视化选项
  * 平滑回零：按时长平滑插值回零以避免关节突跳
  * 手侧参数：支持按左右手自动选择设备并命名话题
  * 新增列举已连接设备序列号的工具

* **文档**
  * 补充双手启动、命名空间、平滑回零与设备列举使用说明

* **Chores**
  * 将启动/辅助脚本随包安装部署
<!-- end of auto-generated comment: release notes by coderabbit.ai -->