### PR TITLE
fix(docs): 同级页面链接改用上级目录相对路径修复 404

### DIFF
--- a/docs/external/en/configuration.mdx
+++ b/docs/external/en/configuration.mdx
@@ -91,7 +91,7 @@ The dexterous hand has 20 joints (5 fingers × 4 joints per finger).
 
 ### Finger and Joint IDs
 
-[Service Calls](./ros2-interface#service-calls) use `finger_id` and `joint_id`:
+[Service Calls](../ros2-interface#service-calls) use `finger_id` and `joint_id`:
 
 | Parameter | Values and Meanings |
 |:----------|:--------------------|
@@ -100,7 +100,7 @@ The dexterous hand has 20 joints (5 fingers × 4 joints per finger).
 
 ### Joint Name Format
 
-[Topic Control](./ros2-interface#topic-control) uses full joint names: `{handedness}_finger{1-5}_joint{1-4}`
+[Topic Control](../ros2-interface#topic-control) uses full joint names: `{handedness}_finger{1-5}_joint{1-4}`
 
 | Index | Joint Name (handedness=right) | Finger |
 |:------|:------------------------------|:-------|

--- a/docs/external/en/quick-start.mdx
+++ b/docs/external/en/quick-start.mdx
@@ -44,7 +44,7 @@ ros2 run wujihand_bringup wave_demo.py
 ```
 
 <Callout type="info">
-When multiple hands are connected, specify the target hand with `--ros-args -p hand_name:=<hand-name>`. See [Multi-hand Configuration](./configuration#multi-hand-configuration) for details.
+When multiple hands are connected, specify the target hand with `--ros-args -p hand_name:=<hand-name>`. See [Multi-hand Configuration](../configuration#multi-hand-configuration) for details.
 </Callout>
 
 ## Launch RViz Visualization

--- a/docs/external/zh/configuration.mdx
+++ b/docs/external/zh/configuration.mdx
@@ -91,7 +91,7 @@ ros2 run wujihand_bringup wave_demo.py --ros-args -p hand_name:=right_hand
 
 ### 手指与关节编号
 
-[服务调用](./ros2-interface#服务调用)使用 `finger_id` 和 `joint_id`：
+[服务调用](../ros2-interface#服务调用)使用 `finger_id` 和 `joint_id`：
 
 | 参数 | 值与含义 |
 |:-----|:---------|
@@ -100,7 +100,7 @@ ros2 run wujihand_bringup wave_demo.py --ros-args -p hand_name:=right_hand
 
 ### 关节名格式
 
-[话题控制](./ros2-interface#话题控制)使用完整关节名：`{handedness}_finger{1-5}_joint{1-4}`
+[话题控制](../ros2-interface#话题控制)使用完整关节名：`{handedness}_finger{1-5}_joint{1-4}`
 
 | 索引 | 关节名 (handedness=right) | 手指 |
 |:-----|:--------------------------|:-----|

--- a/docs/external/zh/quick-start.mdx
+++ b/docs/external/zh/quick-start.mdx
@@ -44,7 +44,7 @@ ros2 run wujihand_bringup wave_demo.py
 ```
 
 <Callout type="info">
-连接多只灵巧手时，需通过 `--ros-args -p hand_name:=<hand-name>` 指定目标手。详见[多手配置](./configuration#多手配置)。
+连接多只灵巧手时，需通过 `--ros-args -p hand_name:=<hand-name>` 指定目标手。详见[多手配置](../configuration#多手配置)。
 </Callout>
 
 ## 启动 RViz 可视化


### PR DESCRIPTION
## 变更概要

修复 4 个 MDX 文件中 6 条指向同级页面的失效链接。

### 背景

docs-center 启用 `trailingSlash: true`，每个 `xxx.mdx` 渲染为 `xxx/` 目录路由。浏览器按路由层级解析相对 URL——从 `configuration/` 出发的 `./ros2-interface` 实际指向 `configuration/ros2-interface`，落到不存在的子路径（404），必须写 `../ros2-interface` 才能正确到达兄弟页面 `ros2-user-guide/ros2-interface/`。

### 修复明细

- `docs/external/{zh,en}/configuration.mdx:94,103`：`./ros2-interface#...` → `../ros2-interface#...`（中英共 4 处）
- `docs/external/{zh,en}/quick-start.mdx:47`：`./configuration#...` → `../configuration#...`（中英共 2 处）

锚点 `#服务调用 / #service-calls`、`#话题控制 / #topic-control`、`#多手配置 / #multi-hand-configuration` 全部保留。

## 自测结果

- 自测环境：本地 `wuji-docs-center` + `pnpm docs:sync`，按路由相对脚本对 `content/docs/` 做全量内链扫描
- 结果：修复前 BROKEN: 22（含此仓 6 条），修复后 BROKEN: 0
- 本仓直接推送被 ruleset 拦截（branch creation restricted），按团队约定走 Fork and Pull 模型，PR 从 fork `yuanyuanxin/wujihandros2` 提起

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 修正了多语言文档中的内部链接路径，确保文档跳转导航正常工作。
  * 更新了配置和快速开始指南中的相对链接引用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->