### PR TITLE
docs: 一代 release notes 链接改 v1

### DIFF
--- a/docs/external/en/installation.mdx
+++ b/docs/external/en/installation.mdx
@@ -16,7 +16,7 @@ title: Installation
   <tbody>
     <tr>
       <td>Wuji Hand SDK</td>
-      <td rowspan="2">See <a href="https://docs.wuji.tech/docs/en/wuji-hand/latest/release-notes/">Release Notes</a> for latest updates</td>
+      <td rowspan="2">See <a href="https://docs.wuji.tech/docs/en/wuji-hand/v1/release-notes/">Release Notes</a> for latest updates</td>
     </tr>
     <tr>
       <td>Firmware</td>

--- a/docs/external/zh/installation.mdx
+++ b/docs/external/zh/installation.mdx
@@ -16,7 +16,7 @@ title: 安装指南
   <tbody>
     <tr>
       <td>Wuji Hand SDK</td>
-      <td rowspan="2">参考<a href="https://docs.wuji.tech/docs/zh/wuji-hand/latest/release-notes/">版本发布记录</a>获取最近更新</td>
+      <td rowspan="2">参考<a href="https://docs.wuji.tech/docs/zh/wuji-hand/v1/release-notes/">版本发布记录</a>获取最近更新</td>
     </tr>
     <tr>
       <td>固件</td>


### PR DESCRIPTION
## Summary

- 配合 wuji-docs-center wuji-hand 目录翻面：原 \`latest\`（一代量产）改名为 \`v1\`，installation.mdx 里指向一代 release notes 的链接同步从 \`/latest/release-notes/\` 改为 \`/v1/release-notes/\`

## Test plan

- [x] 链接目标在 docs-center 实测 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新了英文和中文安装指南中 Wuji Hand SDK 的版本发布说明链接，以指向 v1 版本的最新更新信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->