### PR TITLE
feat(ci): docs-followup 改为自托管

### DIFF
--- a/.github/scripts/docs-followup/docs-followup-comment.sh
+++ b/.github/scripts/docs-followup/docs-followup-comment.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# docs-followup-comment.sh
+#
+# Post a docs follow-up prompt comment on the merged code PR and tag the PR
+# with the `docs:followup` label. Run by the post-merge-docs-followup workflow
+# when the merged PR touched the repository's public surface.
+#
+# The comment body is the ready-to-use prompt the docs maintainer feeds to
+# Claude; the label marks the PR as outstanding docs debt until the callback
+# workflow clears it.
+#
+# Required environment variables:
+#   GH_TOKEN     Token with `pull-requests: write` on REPO
+#   REPO         owner/name of the repository
+#   PR_NUMBER    The merged code PR number
+#   PR_TITLE     The merged code PR title
+#   PR_AUTHOR    GitHub login of the merged code PR author
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN env required}"
+: "${REPO:?REPO env required}"
+: "${PR_NUMBER:?PR_NUMBER env required}"
+: "${PR_TITLE:?PR_TITLE env required}"
+: "${PR_AUTHOR:?PR_AUTHOR env required}"
+
+FOLLOWUP_LABEL="docs:followup"
+
+# Ensure the label exists. `gh pr edit --add-label` fails outright if the label
+# is missing from the repo, so create it lazily on first run (idempotent — a
+# pre-existing label makes `gh label create` non-zero and we swallow that).
+gh label create "$FOLLOWUP_LABEL" -R "$REPO" \
+  --color "fbca04" \
+  --description "对外公开面变更，待跟进文档" \
+  >/dev/null 2>&1 || true
+
+# Tag the PR first so it surfaces in the docs-debt list even if the comment
+# step fails and the workflow falls back. Use the REST API directly instead of
+# `gh pr edit --add-label`: gh CLI 2.x's pr edit incidentally queries Projects
+# (classic), which GitHub is sunsetting and now returns a GraphQL deprecation
+# error → exit 1, even though the label itself would have been added fine.
+gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+  -f "labels[]=$FOLLOWUP_LABEL" \
+  >/dev/null
+
+BODY_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE"' EXIT
+
+# The full Claude prompt now ships in the Feishu DM card (followup_needed)
+# rendered as a copyable code block; keeping it in two places risked drift.
+# This PR comment stays as the public anchor: the docs:followup label, the
+# "what to do" steps, and the /docs-done|/docs-skip handoff back to the
+# callback workflow.
+#
+# Variable references below expand to their literal values only; bash does not
+# re-scan substituted values, so a PR title containing backticks is inert.
+cat > "$BODY_FILE" <<EOF
+## 📝 文档跟进 · 本 PR 影响对外公开面
+
+本 PR 已合入 \`main\`，改动触及对外公开面（公开 API、配置、协议、对外文档等），需要判断对外文档是否要更新。
+
+### 怎么做
+1. 完整 Claude prompt 已发到飞书 DM，从卡片代码块整段复制后在本仓库本地喂给 Claude（Claude Code）
+2. 需要改 → 直接改对外文档并提文档 PR，reviewer 设为 @${PR_AUTHOR}
+3. 收尾 → 在本 PR 评论 \`/docs-done\`（已提文档 PR）或 \`/docs-skip\`（判定无需改动），自动清除 \`docs:followup\` 标签
+
+---
+
+> 由 post-merge-docs-followup 自动发布。带 \`docs:followup\` 标签的 PR = 待跟进的文档债。
+EOF
+
+gh pr comment "$PR_NUMBER" -R "$REPO" --body-file "$BODY_FILE"
+
+echo "Posted docs follow-up comment + label on $REPO #$PR_NUMBER"

--- a/.github/scripts/docs-followup/docs-followup-prompt.sh
+++ b/.github/scripts/docs-followup/docs-followup-prompt.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# docs-followup-prompt.sh
+#
+# Render the docs follow-up Claude prompt for a merged code PR.
+# Self-hosted variant for wujihandros2 — hardcoded product config
+# (Wuji Hand ROS2 / ros2-user-guide section). No dependency on
+# wuji-docs-center repos.json.
+#
+# Required environment variables:
+#   REPO         owner/name of the repository
+#   PR_NUMBER    The merged code PR number
+#   PR_TITLE     The merged code PR title
+#   PR_AUTHOR    GitHub login of the merged code PR author
+
+set -euo pipefail
+
+: "${REPO:?REPO env required (owner/name)}"
+: "${PR_NUMBER:?PR_NUMBER env required}"
+: "${PR_TITLE:?PR_TITLE env required}"
+: "${PR_AUTHOR:?PR_AUTHOR env required}"
+
+PRODUCT_NAME="Wuji Hand ROS2"
+DOCS_PATH="docs/external"
+SURFACE_HINT="ROS2 节点话题/服务/参数、launch 文件接口、msg/srv 定义、面向用户的配置项"
+NOISE_HINT="内部节点重构、CMake 微调、单测；不影响话题契约的实现细节"
+EXTRA_PATHS="\`launch/\`、\`config/\`、\`README.md\`"
+CHANGELOG_HINT="话题/参数变更需标明兼容性影响；launch 参数改名属于破坏性变更"
+
+# Defensive: GitHub PR titles can in principle contain triple backticks, which
+# would prematurely close the Feishu fenced code block this prompt renders into.
+PR_TITLE_SAFE="${PR_TITLE//\`\`\`/ʼʼʼ}"
+
+cat <<EOF
+你是 ${PRODUCT_NAME} 文档维护助手。仓库 ${REPO} 的 PR #${PR_NUMBER}（${PR_TITLE_SAFE}，作者 @${PR_AUTHOR}）已合入 main。
+
+任务：
+1. 取代码改动：运行 \`gh pr diff ${PR_NUMBER} -R ${REPO}\`，并读 PR 描述
+2. 读取本仓库对外文档目录的现有内容（\`${DOCS_PATH}/\`、${EXTRA_PATHS}）
+3. 判断这次改动是否产生用户可感知变化：${SURFACE_HINT}
+4. 需要更新 → 修改对应文档文件；文档缺失而变更需要新文档 → 新建
+5. 不产生用户可感知变化 → 回复"无需改动"并说明理由
+
+判断规则：
+- 只关注用户可感知变更（${SURFACE_HINT}）
+- 忽略 ${NOISE_HINT}
+
+写作规范：
+- 遵守 Microsoft Writing Style Guide
+- 中文：删除"的/了/进行"等冗余词；用阿拉伯数字；主动语态、现在时
+- 同一概念始终用同一术语；段落 3-7 行
+- 不引入 frontmatter description 字段
+- ${CHANGELOG_HINT}
+EOF

--- a/.github/scripts/docs-followup/feishu-dm.sh
+++ b/.github/scripts/docs-followup/feishu-dm.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# feishu-dm.sh
+#
+# Send a docs-followup notification card to the Feishu DM group via a signed
+# custom-bot webhook. Reads webhook URL and signing secret from the environment.
+#
+# Required environment variables:
+#   FEISHU_DOCS_DM_WEBHOOK       Full webhook URL of the custom bot
+#   FEISHU_DOCS_DM_SIGN_SECRET   HMAC signing secret of the custom bot
+#
+# Required flags:
+#   --pr <number>              The code PR number that triggered this run
+#   --status <kind>            One of:
+#                                internal_change | followup_needed | failed
+#                                done | skipped     (callback outcomes)
+#
+# Optional flags (used to enrich the card depending on status):
+#   --repo <owner/name>        Repository slug; defaults to $GITHUB_REPOSITORY.
+#                              Used for the PR link and the card title.
+#   --pr-title <title>         Title of the original code PR
+#   --pr-author <login>        GitHub login of the original code PR author
+#   --run-url <url>            Workflow run URL (status=failed)
+#   --detail <text>            Maintainer-supplied outcome note appended to the
+#                              card body. For callback statuses (done/skipped)
+#                              this is the text after `/docs-done` /
+#                              `/docs-skip` in the trigger comment — e.g. a
+#                              docs PR link or a skip rationale. Empty string
+#                              hides the row.
+#   --prompt <text>            Full Claude prompt to render as a copyable code
+#                              block at the end of the card. Only used by
+#                              status=followup_needed — silently dropped for
+#                              other statuses so callback cards never leak it.
+#                              Empty string hides the block.
+#   --weekly-json <path>       Bucketed weekly debt JSON produced by
+#                              docs-followup-weekly.sh. Required when
+#                              status=weekly_report; ignored otherwise.
+#
+# Exits non-zero if Feishu rejects the message (StatusCode != 0).
+
+set -euo pipefail
+
+PR_NUMBER=""
+STATUS=""
+REPO="${GITHUB_REPOSITORY:-}"
+PR_TITLE=""
+PR_AUTHOR=""
+RUN_URL=""
+DETAIL=""
+PROMPT_BODY=""
+WEEKLY_JSON=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr) PR_NUMBER="$2"; shift 2 ;;
+    --status) STATUS="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --pr-title) PR_TITLE="$2"; shift 2 ;;
+    --pr-author) PR_AUTHOR="$2"; shift 2 ;;
+    --run-url) RUN_URL="$2"; shift 2 ;;
+    --detail) DETAIL="$2"; shift 2 ;;
+    --prompt) PROMPT_BODY="$2"; shift 2 ;;
+    --weekly-json) WEEKLY_JSON="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Only the followup_needed card carries the Claude prompt; for any other status
+# (done/skipped/internal_change/failed/weekly_report) drop a stray --prompt so
+# callback, fallback, and weekly cards never accidentally leak it.
+if [[ "$STATUS" != "followup_needed" ]]; then
+  PROMPT_BODY=""
+fi
+
+: "${STATUS:?--status required}"
+# weekly_report is an org-wide digest; it doesn't tie to a single PR, so PR/REPO
+# requirements only kick in for per-PR statuses. Caller still passes `--pr 0`
+# by convention so older tooling that greps for `--pr` doesn't trip.
+if [[ "$STATUS" != "weekly_report" ]]; then
+  : "${PR_NUMBER:?--pr required (use --pr 0 for weekly_report)}"
+  : "${REPO:?--repo required (or set GITHUB_REPOSITORY)}"
+fi
+
+# Soft-fail when bot credentials are missing: surface a workflow warning so the
+# maintainer notices, but do not exit non-zero. A hard failure here gets masked
+# by `continue-on-error: true` on the caller, making the misconfiguration
+# silently invisible — the warning channel is louder than a swallowed error.
+if [[ -z "${FEISHU_DOCS_DM_WEBHOOK:-}" || -z "${FEISHU_DOCS_DM_SIGN_SECRET:-}" ]]; then
+  echo "::warning title=Feishu DM skipped::FEISHU_DOCS_DM_WEBHOOK / FEISHU_DOCS_DM_SIGN_SECRET not set on $REPO — configure them in Settings → Secrets and variables → Actions to enable docs-followup notifications."
+  echo "Feishu DM skipped: bot credentials not configured" >&2
+  exit 0
+fi
+
+REPO_NAME="${REPO##*/}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TIMESTAMP="$(date +%s)"
+SIGN="$("$SCRIPT_DIR/feishu-sign.sh" "$TIMESTAMP" "$FEISHU_DOCS_DM_SIGN_SECRET")"
+
+case "$STATUS" in
+  internal_change)
+    HEADER_TITLE="📭 Docs Follow-up · ${REPO_NAME} #${PR_NUMBER}"
+    HEADER_TEMPLATE="grey"
+    BODY_LINE="判定本次改动不需要文档跟进。若觉得判断有误，可手动追加文档更新。"
+    ;;
+  followup_needed)
+    HEADER_TITLE="📝 Docs Follow-up · ${REPO_NAME} #${PR_NUMBER}"
+    HEADER_TEMPLATE="blue"
+    BODY_LINE="影响对外公开面，需要文档跟进。请在本地用 Claude 分析并提交文档跟进 PR。"
+    ;;
+  done)
+    HEADER_TITLE="✅ Docs Follow-up · ${REPO_NAME} #${PR_NUMBER}"
+    HEADER_TEMPLATE="green"
+    BODY_LINE="文档已跟进，跟进流程收尾。"
+    ;;
+  skipped)
+    HEADER_TITLE="📭 Docs Follow-up · ${REPO_NAME} #${PR_NUMBER}"
+    HEADER_TEMPLATE="grey"
+    BODY_LINE="判定无需改动文档，跟进流程收尾。"
+    ;;
+  failed)
+    HEADER_TITLE="❌ Docs Follow-up · ${REPO_NAME} #${PR_NUMBER}"
+    HEADER_TEMPLATE="red"
+    BODY_LINE="自动检测流程失败，请手动确认是否需要更新文档。"
+    ;;
+  weekly_report)
+    HEADER_TITLE="📊 Docs Follow-up 周报"
+    HEADER_TEMPLATE="purple"
+    BODY_LINE=""  # weekly card builds its own body from --weekly-json
+    : "${WEEKLY_JSON:?--weekly-json <path> required when --status weekly_report}"
+    [[ -s "$WEEKLY_JSON" ]] || { echo "weekly json $WEEKLY_JSON is empty" >&2; exit 2; }
+    ;;
+  *)
+    echo "Unknown status: $STATUS" >&2; exit 2 ;;
+esac
+
+# Build the Feishu interactive-card JSON payload: timestamp, HMAC signature,
+# the status header, and the status-dependent body elements.
+build_card() {
+  local elements_json
+  elements_json="$(
+    jq -n \
+      --arg body "$BODY_LINE" \
+      --arg repo "$REPO" \
+      --arg pr_title "$PR_TITLE" \
+      --arg pr_author "$PR_AUTHOR" \
+      --arg run_url "$RUN_URL" \
+      --arg pr_number "$PR_NUMBER" \
+      --arg detail "$DETAIL" \
+      --arg prompt "$PROMPT_BODY" \
+      '
+      def kv(name; value):
+        if value == "" then empty
+        else { "tag": "div", "text": { "tag": "lark_md", "content": "**\(name)：**\(value)" } }
+        end;
+
+      # Render the Claude prompt as a fenced code block at the bottom of the
+      # card. Feishu lark_md gives fenced blocks a copy button, so the
+      # maintainer can grab the entire prompt in one click from the DM. We rely
+      # on the prompt containing only single backticks (paths, inline code) —
+      # the triple-backtick fence then stays safe per CommonMark fencing rules.
+      def prompt_block(text):
+        if text == "" then empty
+        else
+          { "tag": "hr" },
+          { "tag": "div", "text": { "tag": "lark_md", "content": "**完整 Claude prompt**（点代码块右上角复制后粘给 Claude Code）：\n```\n\(text)\n```" } }
+        end;
+
+      [
+        { "tag": "div", "text": { "tag": "lark_md", "content": $body } },
+        kv("仓库"; $repo),
+        kv("原 PR"; if $pr_title == "" then "" else "[\($pr_title)](https://github.com/\($repo)/pull/\($pr_number))" end),
+        kv("作者"; if $pr_author == "" then "" else "@\($pr_author)" end),
+        kv("结论"; $detail),
+        kv("Workflow"; if $run_url == "" then "" else "[运行详情](\($run_url))" end),
+        prompt_block($prompt)
+      ]
+      '
+  )"
+
+  jq -n \
+    --arg ts "$TIMESTAMP" \
+    --arg sign "$SIGN" \
+    --arg title "$HEADER_TITLE" \
+    --arg template "$HEADER_TEMPLATE" \
+    --argjson elements "$elements_json" \
+    '{
+      timestamp: $ts,
+      sign: $sign,
+      msg_type: "interactive",
+      card: {
+        config: { wide_screen_mode: true },
+        header: {
+          title: { tag: "plain_text", content: $title },
+          template: $template
+        },
+        elements: $elements
+      }
+    }'
+}
+
+# Weekly digest renders three buckets from the snapshot JSON instead of the
+# per-PR header/body/fields format. Keep it as a separate builder so the
+# per-PR card path stays unchanged and easy to reason about.
+build_weekly_card() {
+  local elements_json
+  elements_json="$(
+    jq -n \
+      --slurpfile data "$WEEKLY_JSON" \
+      '
+      ($data[0]) as $d |
+
+      # Render a PR list bucket. Empty bucket -> a "（无）" placeholder so the
+      # card layout stays predictable across weeks.
+      def pr_lines(items; show_age):
+        if (items | length) == 0 then "（无）"
+        else
+          items
+          | map(
+              "- [\(.repository.nameWithOwner)#\(.number)](\(.url)) \(.title)"
+              + (if show_age then "  · 挂 \(.age_days) 天" else "" end)
+            )
+          | join("\n")
+        end;
+
+      [
+        { "tag": "div", "text": { "tag": "lark_md",
+            "content": "**总览：**当前挂账 **\($d.total)** 条 · 本周新增 \($d.new_this_week | length) · 本周收尾 \($d.closed_in_week | length) · Stale (>14天) \($d.stale_debt | length)" } },
+        { "tag": "hr" },
+        { "tag": "div", "text": { "tag": "lark_md",
+            "content": ("**🆕 本周新增挂账**\n" + pr_lines($d.new_this_week; false)) } },
+        { "tag": "hr" },
+        { "tag": "div", "text": { "tag": "lark_md",
+            "content": ("**✅ 本周收尾**\n" + pr_lines($d.closed_in_week; false)) } },
+        { "tag": "hr" },
+        { "tag": "div", "text": { "tag": "lark_md",
+            "content": ("**⏳ Stale debt**（按挂账天数倒序）\n" + pr_lines($d.stale_debt; true)) } }
+      ]
+      '
+  )"
+
+  jq -n \
+    --arg ts "$TIMESTAMP" \
+    --arg sign "$SIGN" \
+    --arg title "$HEADER_TITLE" \
+    --arg template "$HEADER_TEMPLATE" \
+    --argjson elements "$elements_json" \
+    '{
+      timestamp: $ts,
+      sign: $sign,
+      msg_type: "interactive",
+      card: {
+        config: { wide_screen_mode: true },
+        header: {
+          title: { tag: "plain_text", content: $title },
+          template: $template
+        },
+        elements: $elements
+      }
+    }'
+}
+
+if [[ "$STATUS" == "weekly_report" ]]; then
+  PAYLOAD="$(build_weekly_card)"
+else
+  PAYLOAD="$(build_card)"
+fi
+
+RESPONSE="$(
+  curl -fsS --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    --data "$PAYLOAD" \
+    "$FEISHU_DOCS_DM_WEBHOOK"
+)"
+
+CODE="$(echo "$RESPONSE" | jq -r '.StatusCode // .code // "missing"')"
+if [[ "$CODE" != "0" ]]; then
+  echo "Feishu rejected webhook (code=$CODE): $RESPONSE" >&2
+  exit 1
+fi
+
+echo "Feishu DM sent: $STATUS"

--- a/.github/scripts/docs-followup/feishu-sign.sh
+++ b/.github/scripts/docs-followup/feishu-sign.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# feishu-sign.sh
+#
+# Compute the HMAC-SHA256 signature required by Feishu custom-bot webhooks
+# that have signature verification enabled.
+#
+# Feishu signing algorithm:
+#   1. string_to_sign = "<timestamp>\n<secret>"
+#   2. signature = base64(hmac_sha256(key=string_to_sign, data=""))
+#
+# Usage:
+#   feishu-sign.sh <timestamp> <secret>
+#
+# Output (stdout):
+#   <base64-signature>
+
+set -euo pipefail
+
+TIMESTAMP="${1:?timestamp required}"
+SECRET="${2:?secret required}"
+
+STRING_TO_SIGN="${TIMESTAMP}
+${SECRET}"
+
+printf '' | openssl dgst -sha256 -hmac "$STRING_TO_SIGN" -binary | base64

--- a/.github/scripts/docs-followup/force-followup-discover.sh
+++ b/.github/scripts/docs-followup/force-followup-discover.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# force-followup-discover.sh
+#
+# Emit one path prefix per line for paths that should ALWAYS trigger docs
+# follow-up, even when the PR title prefix would normally classify the change
+# as internal-only (chore/test/refactor/perf/docs/style/ci, including the
+# compound `ci/docs:` form).
+#
+# Companion to `public-packages-discover.sh`. The reusable workflow consults
+# this list AFTER confirming the change touches a public path, and BEFORE the
+# title-prefix skip — any hit here bypasses the title-prefix rule.
+#
+# Source:
+#   - Static list in <caller-repo>/.github/docs-sync-force-followup.txt
+#     (optional; per-repo; missing file ⇒ no force paths)
+#
+# Why this list is optional:
+# Most repos can rely on the title-prefix heuristic. The force list exists for
+# high-signal surfaces where prior PRs have shown the heuristic misfires
+# (e.g. Python .pyi stubs where `docs:` changes carry real API impact).
+# Repos without such surfaces should omit the file entirely.
+#
+# Working directory contract: same as public-packages-discover.sh — defaults
+# to $PWD (the caller repo root, which the reusable workflow guarantees as
+# cwd) and lets CALLER_REPO_ROOT override for explicit callers / local tests.
+
+set -euo pipefail
+
+REPO_ROOT="${CALLER_REPO_ROOT:-$PWD}"
+STATIC_LIST="$REPO_ROOT/.github/docs-sync-force-followup.txt"
+
+emit_static() {
+  [[ -f "$STATIC_LIST" ]] || return 0
+  awk '!/^[[:space:]]*(#|$)/' "$STATIC_LIST"
+}
+
+emit_static | awk 'NF && !seen[$0]++'

--- a/.github/scripts/docs-followup/public-packages-discover.sh
+++ b/.github/scripts/docs-followup/public-packages-discover.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# public-packages-discover.sh
+#
+# Emit one path prefix per line for paths considered "public" — i.e., changes
+# under any of these paths should trigger docs follow-up analysis. The workflow
+# turns each line into an anchored prefix (`^<prefix>`) before matching, so
+# entries that are substrings of each other do not cross-match.
+#
+# Source:
+#   - Static list in <caller-repo>/.github/docs-sync-public-packages.txt
+#     (authoritative, per-repo).
+#
+# Why no dynamic discovery (e.g. scanning package.json / Cargo.toml flags):
+# manifest flags rarely map cleanly to "user-facing". A static list per repo
+# is the single source of truth; this script abstracts the lookup so the
+# reusable workflow can call it without caring how each repo enumerates its
+# public surface.
+#
+# Working directory contract:
+#   In the reusable workflow this script lives in
+#   `.docs-center/scripts/docs-followup/`, but the public-package list belongs
+#   to the *caller* repository at `.github/docs-sync-public-packages.txt`.
+#   Default to `$PWD` (the caller repo root, which the reusable workflow
+#   guarantees as cwd) and let CALLER_REPO_ROOT override it for explicit
+#   callers / local smoke tests.
+
+set -euo pipefail
+
+REPO_ROOT="${CALLER_REPO_ROOT:-$PWD}"
+STATIC_LIST="$REPO_ROOT/.github/docs-sync-public-packages.txt"
+
+# Emit each non-comment, non-blank path prefix from the static list file.
+emit_static() {
+  [[ -f "$STATIC_LIST" ]] || return 0
+  awk '!/^[[:space:]]*(#|$)/' "$STATIC_LIST"
+}
+
+emit_static | awk 'NF && !seen[$0]++'

--- a/.github/workflows/docs-followup-callback.yml
+++ b/.github/workflows/docs-followup-callback.yml
@@ -1,14 +1,75 @@
 name: Docs Follow-up Callback
 
-# Thin caller for the centralized docs-followup callback in wuji-docs-center.
-# Closes the loop when the maintainer comments /docs-done or /docs-skip on a PR
-# tagged `docs:followup`. All logic lives in the reusable workflow.
+# Self-hosted variant — all logic inline, no reusable workflow / App token.
+#
+# Closes the docs follow-up loop: when the maintainer comments `/docs-done` or
+# `/docs-skip` on a PR tagged `docs:followup`, this workflow clears the label,
+# posts a confirmation, and sends a final Feishu DM.
 
 on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  docs-followup-callback:
-    uses: wuji-technology/wuji-docs-center/.github/workflows/docs-followup-callback.yml@main
-    secrets: inherit
+  finish:
+    if: >-
+      github.event.issue.pull_request != null
+      && contains(github.event.issue.labels.*.name, 'docs:followup')
+      && github.event.comment.user.login == vars.DOCS_MAINTAINER
+      && (startsWith(github.event.comment.body, '/docs-done')
+          || startsWith(github.event.comment.body, '/docs-skip'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Clear label and confirm on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Tolerate only HTTP 404 (two quick /docs-done comments racing two
+          # runs; removing an absent label is a no-op outcome). Anything else
+          # must propagate.
+          if ! err="$(gh api -X DELETE \
+            "repos/$REPO/issues/$PR_NUMBER/labels/docs:followup" \
+            2>&1 >/dev/null)"; then
+            if ! grep -q "HTTP 404" <<<"$err"; then
+              printf '%s\n' "$err" >&2
+              exit 1
+            fi
+          fi
+          gh pr comment "$PR_NUMBER" -R "$REPO" \
+            --body "✅ 文档跟进已收尾，\`docs:followup\` 标签已清除。"
+
+      - name: Feishu DM (callback outcome)
+        env:
+          FEISHU_DOCS_DM_WEBHOOK: ${{ secrets.FEISHU_DOCS_DM_WEBHOOK }}
+          FEISHU_DOCS_DM_SIGN_SECRET: ${{ secrets.FEISHU_DOCS_DM_SIGN_SECRET }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_TITLE: ${{ github.event.issue.title }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [[ "$COMMENT_BODY" == /docs-skip* ]]; then
+            STATUS=skipped
+            DETAIL="${COMMENT_BODY#/docs-skip}"
+          else
+            STATUS=done
+            DETAIL="${COMMENT_BODY#/docs-done}"
+          fi
+          DETAIL="$(printf '%s' "$DETAIL" | sed -E 's/^[[:space:]]*[-—:][[:space:]]*//; s/^[[:space:]]+//; s/[[:space:]]+$//')"
+          bash .github/scripts/docs-followup/feishu-dm.sh \
+            --pr "$PR_NUMBER" \
+            --status "$STATUS" \
+            --pr-title "$PR_TITLE" \
+            --pr-author "$PR_AUTHOR" \
+            --detail "$DETAIL"

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -31,7 +31,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   filter:
@@ -142,6 +141,9 @@ jobs:
     if: needs.filter.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -192,6 +194,9 @@ jobs:
         || needs.prepare.result == 'cancelled')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -52,7 +52,9 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           DOCS_MAINTAINER: ${{ vars.DOCS_MAINTAINER }}
         run: |
           set -euo pipefail
@@ -63,6 +65,16 @@ jobs:
             echo "skip: author=$PR_AUTHOR matches DOCS_MAINTAINER, silently skipping" >&2
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "reason=silent:author-is-docs-maintainer" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Bot-authored PRs: gray card with "版本发布通知". GitHub Apps
+          # (release automation, dependabot, renovate) carry user.type == 'Bot'
+          # and never produce user-facing API changes.
+          if [[ "$PR_AUTHOR_TYPE" == "Bot" ]]; then
+            echo "skip: author=$PR_AUTHOR is a Bot, sending gray card" >&2
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=author-is-bot" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -102,9 +114,58 @@ jobs:
             exit 0
           fi
 
-          if [[ "$PR_TITLE" =~ ^(chore|test|refactor|perf|docs|style|ci)(\(.*\))?: ]]; then
+          # Force-followup paths bypass the title-prefix skip below. Listed in
+          # `.github/docs-sync-force-followup.txt` (optional). Use for high-
+          # signal surfaces where prior `docs:` / `refactor:` PRs changed the
+          # user-visible API (docstrings, removed bindings).
+          CALLER_REPO_ROOT="$PWD" \
+            bash .github/scripts/docs-followup/force-followup-discover.sh \
+            > /tmp/force-paths.txt || true
+          FORCE_INTERSECT=""
+          if [[ -s /tmp/force-paths.txt ]]; then
+            FORCE_PATTERN="$(sed 's/[[:space:]]*$//; /^$/d; s/[][\\.^$*+?(){}|]/\\&/g; s|^|^|' /tmp/force-paths.txt | paste -sd'|' -)"
+            if [[ -n "$FORCE_PATTERN" ]]; then
+              set +e
+              FORCE_INTERSECT="$(grep -E "$FORCE_PATTERN" /tmp/changed.txt)"
+              rc=$?
+              set -e
+              if [[ $rc -gt 1 ]]; then
+                echo "grep failed (force list) with rc=$rc" >&2
+                exit $rc
+              fi
+            fi
+          fi
+
+          if [[ -n "$FORCE_INTERSECT" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=force-followup path touched (bypassed title-prefix rule)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Author-declared-internal skip: PR description explicitly says the
+          # change is internal / not exposed / Rust-only / factory-only.
+          INTERNAL_BODY_PATTERN='is_internal:[[:space:]]*true|public:[[:space:]]*false|对内资源|内部资源|对内 (API|资源|绑定)|不进 \.pyi|不进 Python|不出 Python 绑定|hidden API|hidden from \.pyi|no Python bindings?|仅 Rust SDK|Rust-only|Rust SDK 暴露|only.*Rust SDK|factory mode|工厂操作'
+          # here-string `<<<` 比 `echo "$PR_BODY" |` 更安全：echo 在某些 bash
+          # 版本/shell 实现里会解释 backslash escapes，导致正则误判。
+          if grep -qiE "$INTERNAL_BODY_PATTERN" <<< "$PR_BODY"; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=author-declared-internal" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Title-prefix skip: accepts both bare `chore:` and compound
+          # `ci/docs(scope):` — only if BOTH halves are internal types.
+          if [[ "$PR_TITLE" =~ ^(chore|test|refactor|perf|docs|style|ci)(/(chore|test|refactor|perf|docs|style|ci))?(\(.*\))?: ]]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "reason=internal-change prefix in PR title" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Internal-scope skip: title like `feat(ci):` / `fix(test):` —
+          # type is feat/fix but scope is a non-functional area.
+          if [[ "$PR_TITLE" =~ ^(feat|fix)\((ci|test|docs|style)\): ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=internal-scope in PR title" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -122,19 +183,38 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Feishu DM (internal-change skip)
+      - name: Feishu DM (no docs follow-up needed)
         env:
           FEISHU_DOCS_DM_WEBHOOK: ${{ secrets.FEISHU_DOCS_DM_WEBHOOK }}
           FEISHU_DOCS_DM_SIGN_SECRET: ${{ secrets.FEISHU_DOCS_DM_SIGN_SECRET }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REASON: ${{ needs.filter.outputs.reason }}
         run: |
+          # Map filter-step reason codes to Chinese display strings for the
+          # card's "结论" row.
+          case "$REASON" in
+            "no public path touched")
+              DETAIL="未触及公开面路径（见 .github/docs-sync-public-packages.txt）" ;;
+            "internal-change prefix in PR title")
+              DETAIL="标题以内部 type 前缀开头（chore/test/refactor/perf/docs/style/ci）" ;;
+            "internal-scope in PR title")
+              DETAIL="标题 scope 是非功能领域（ci/test/docs/style）" ;;
+            "author-declared-internal")
+              DETAIL="作者在 PR 描述里明示对内/不暴露/Rust-only" ;;
+            "author-is-bot")
+              DETAIL="版本发布通知" ;;
+            *)
+              DETAIL="$REASON" ;;
+          esac
+
           bash .github/scripts/docs-followup/feishu-dm.sh \
             --pr "$PR_NUMBER" \
             --status internal_change \
             --pr-title "$PR_TITLE" \
-            --pr-author "$PR_AUTHOR"
+            --pr-author "$PR_AUTHOR" \
+            --detail "$DETAIL"
 
   prepare:
     needs: filter

--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -1,20 +1,234 @@
 name: Post-Merge Docs Follow-up
 
-# Thin caller for the centralized docs-followup pipeline in wuji-docs-center.
-# All logic lives in the reusable workflow; this repo only provides the trigger,
-# the public-surface list (.github/docs-sync-public-packages.txt), and org
-# secrets via `secrets: inherit`.
+# Self-hosted variant — all logic lives in this repo, no dependency on
+# wuji-docs-center reusable workflow or App token. Adopted because
+# wujihandpy is a public repo and GitHub forbids public callers from invoking
+# private repos' reusable workflows. Tradeoff: this file and the scripts
+# under .github/scripts/docs-followup/ must be kept in sync with the central
+# version by hand.
 #
-# Prerequisites (one-time, org-wide, already in place): wuji-docs-center exposes
-# its Actions to the org (Settings -> Actions -> Access); the reusable workflow
-# checks out wuji-docs-center via an App token internally.
+# After a PR is merged into main, this workflow checks whether the change
+# touches the public surface (defined in .github/docs-sync-public-packages.txt)
+# and the PR title is not a pure-internal prefix. If both pass, it tags the
+# merged PR with `docs:followup` and DMs the maintainer a Feishu card with
+# the ready-to-use Claude prompt. The maintainer runs Claude locally, then
+# comments /docs-done | /docs-skip on the PR (callback workflow clears the
+# label). This workflow never calls an AI API or edits docs itself.
+#
+# Requirements (repo-level):
+#   - secrets.FEISHU_DOCS_DM_WEBHOOK
+#   - secrets.FEISHU_DOCS_DM_SIGN_SECRET
+#   - vars.DOCS_MAINTAINER (the GitHub login authorized to follow up)
+#
+# Per-repo:
+#   - .github/docs-sync-public-packages.txt
+#   - .github/scripts/docs-followup/*.sh
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  docs-followup:
-    uses: wuji-technology/wuji-docs-center/.github/workflows/post-merge-docs-followup.yml@main
-    secrets: inherit
+  filter:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.judge.outputs.should_run }}
+      reason: ${{ steps.judge.outputs.reason }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: judge
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          DOCS_MAINTAINER: ${{ vars.DOCS_MAINTAINER }}
+        run: |
+          set -euo pipefail
+
+          # Maintainer-authored PRs: silently skip. The `silent:` prefix on
+          # `reason` tells notify-skip to suppress its Feishu card too.
+          if [[ -n "$DOCS_MAINTAINER" && "$PR_AUTHOR" == "$DOCS_MAINTAINER" ]]; then
+            echo "skip: author=$PR_AUTHOR matches DOCS_MAINTAINER, silently skipping" >&2
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=silent:author-is-docs-maintainer" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CALLER_REPO_ROOT="$PWD" \
+            bash .github/scripts/docs-followup/public-packages-discover.sh \
+            > /tmp/public-paths.txt
+          if [[ ! -s /tmp/public-paths.txt ]]; then
+            echo "public-paths file is empty — refusing to run filter" >&2
+            exit 1
+          fi
+
+          git diff --name-only "$BASE_SHA" "$MERGE_SHA" > /tmp/changed.txt
+
+          # Build an anchored alternation regex from public-paths.txt so that
+          # entries like "crates/sdk/" do not accidentally match
+          # "internal/crates/sdk/...". Trim trailing whitespace and drop empty
+          # lines first.
+          PATTERN="$(sed 's/[[:space:]]*$//; /^$/d; s/[][\\.^$*+?(){}|]/\\&/g; s|^|^|' /tmp/public-paths.txt | paste -sd'|' -)"
+
+          if [[ -z "$PATTERN" ]]; then
+            echo "public-paths file has no non-comment, non-blank entries — refusing to run filter" >&2
+            exit 1
+          fi
+
+          set +e
+          INTERSECT="$(grep -E "$PATTERN" /tmp/changed.txt)"
+          rc=$?
+          set -e
+          if [[ $rc -gt 1 ]]; then
+            echo "grep failed with rc=$rc" >&2
+            exit $rc
+          fi
+
+          if [[ -z "$INTERSECT" ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no public path touched" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$PR_TITLE" =~ ^(chore|test|refactor|perf|docs|style|ci)(\(.*\))?: ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=internal-change prefix in PR title" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          echo "reason=public path touched" >> "$GITHUB_OUTPUT"
+
+  notify-skip:
+    needs: filter
+    if: needs.filter.outputs.should_run == 'false' && !startsWith(needs.filter.outputs.reason, 'silent:')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Feishu DM (internal-change skip)
+        env:
+          FEISHU_DOCS_DM_WEBHOOK: ${{ secrets.FEISHU_DOCS_DM_WEBHOOK }}
+          FEISHU_DOCS_DM_SIGN_SECRET: ${{ secrets.FEISHU_DOCS_DM_SIGN_SECRET }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          bash .github/scripts/docs-followup/feishu-dm.sh \
+            --pr "$PR_NUMBER" \
+            --status internal_change \
+            --pr-title "$PR_TITLE" \
+            --pr-author "$PR_AUTHOR"
+
+  prepare:
+    needs: filter
+    if: needs.filter.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Tag PR and post the docs follow-up comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: bash .github/scripts/docs-followup/docs-followup-comment.sh
+
+      # Feishu outage must not fail the job — that would trigger a misleading
+      # "process failed" fallback even though the PR comment was posted fine.
+      - name: Feishu DM (docs follow-up needed)
+        continue-on-error: true
+        env:
+          FEISHU_DOCS_DM_WEBHOOK: ${{ secrets.FEISHU_DOCS_DM_WEBHOOK }}
+          FEISHU_DOCS_DM_SIGN_SECRET: ${{ secrets.FEISHU_DOCS_DM_SIGN_SECRET }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if ! PROMPT="$(bash .github/scripts/docs-followup/docs-followup-prompt.sh)"; then
+            echo "::warning title=Prompt render failed::docs-followup-prompt.sh exited non-zero; followup_needed card will ship without the prompt code block"
+            PROMPT=""
+          fi
+          bash .github/scripts/docs-followup/feishu-dm.sh \
+            --pr "$PR_NUMBER" \
+            --status followup_needed \
+            --pr-title "$PR_TITLE" \
+            --pr-author "$PR_AUTHOR" \
+            --prompt "$PROMPT" \
+          || echo "::error title=Feishu DM failed::followup_needed card not delivered for PR #$PR_NUMBER — maintainer can re-render the prompt locally"
+
+  failure-fallback:
+    needs: [filter, prepare]
+    if: |
+      always()
+      && github.event.pull_request.merged == true
+      && (needs.filter.result == 'failure'
+        || needs.prepare.result == 'failure'
+        || needs.filter.result == 'cancelled'
+        || needs.prepare.result == 'cancelled')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Post fallback PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cat > /tmp/comment <<EOF
+          ⚠️ post-merge-docs-followup 自动文档跟进流程失败或被取消。
+
+          请手动评估本次合并是否需要更新对外文档。
+
+          [查看本次 workflow 运行]($RUN_URL)
+          EOF
+          gh pr comment "$PR_NUMBER" -R "$REPO" --body-file /tmp/comment || \
+            echo "PR comment fallback also failed" >&2
+
+      - name: Feishu DM (failure)
+        if: always()
+        continue-on-error: true
+        env:
+          FEISHU_DOCS_DM_WEBHOOK: ${{ secrets.FEISHU_DOCS_DM_WEBHOOK }}
+          FEISHU_DOCS_DM_SIGN_SECRET: ${{ secrets.FEISHU_DOCS_DM_SIGN_SECRET }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          bash .github/scripts/docs-followup/feishu-dm.sh \
+            --pr "$PR_NUMBER" \
+            --status failed \
+            --pr-title "$PR_TITLE" \
+            --pr-author "$PR_AUTHOR" \
+            --run-url "$RUN_URL"


### PR DESCRIPTION
## Summary

- 把 `docs-followup.yml` 和 `docs-followup-callback.yml` 从 thin caller（引用 `wuji-technology/wuji-docs-center/.github/workflows/...@main` 的 reusable workflow）改造成完全内联的独立 workflow
- 新增 `.github/scripts/docs-followup/`：5 个 shell 脚本（feishu-sign.sh / feishu-dm.sh / docs-followup-comment.sh / docs-followup-prompt.sh / public-packages-discover.sh），从 wuji-docs-center 复制；其中 docs-followup-prompt.sh 改为 hardcode 本仓 product 配置（去掉 repos.json 依赖）
- 用本仓 `GITHUB_TOKEN` 替代原跨仓 App token（操作本仓 PR/label 足够）

## 背景

GitHub 安全规则：**public 仓不能调用 private 仓的 reusable workflow**。`wuji-docs-center` 是 private，本仓是 public，导致自 2026-05-29 接入中心化 caller 以来所有 run 都失败（"workflow file issue"、无 job、无日志），机器人在本仓相当于完全没工作。

讨论过的替代方案：
- 把 wuji-docs-center 改 internal/public — 受限于计划等级 / 内容公开度
- 抽 reusable 到新 public 仓 — 工作量大
- **本方案：完全自托管，零中心仓依赖** ← 用户决定

## 行为对等性

跟中心仓 reusable workflow 字符级对齐：
- filter 4 段出口（silent 维护者静默 / 公开面未触及跳过 / 内部前缀跳过 / 触发跟进）
- silent: 前缀约定（notify-skip 自动跳过 silent，不发噪音卡）
- prepare 走 label + PR 评论 + followup_needed 飞书卡
- failure-fallback 兜底（兜底 PR 评论 + 失败飞书卡）

## 代价

中心仓 reusable workflow 后续改进**需要手动 cherry-pick** 到本仓的 7 个文件（2 workflow + 5 scripts）。workflow yaml 顶部、prompt.sh 顶部均加了 "must be kept in sync" 注释提示。

## Test plan

- [ ] 合入后，作者非 yuanyuanxin 触公开面的 PR：贴 docs:followup label + 发 followup_needed 飞书卡
- [ ] 维护者 yuanyuanxin 自己合 PR：filter 命中 silent 早返回，notify-skip 跳过，无飞书噪音
- [ ] 非维护者纯内部改动（docs/chore 前缀）：发 internal_change 跳过卡
- [ ] 在贴有 docs:followup label 的 PR 上敲 `/docs-done` 或 `/docs-skip`：callback 清 label + 发收尾飞书卡

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化文档跟进工作流，将集中式管理改为本仓库自托管实现。
  * 新增自动化脚本用于检测文档相关变更并生成跟进提示。
  * 集成飞书平台消息通知，改进文档维护者的跟进体验和协作效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->