### PR TITLE
docs(changelog): add dual-hand launch, homing, and driver params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- One-command dual-hand bringup (`wujihand_dual.launch.py`): auto-discovers connected hands by USB serial number and starts one driver per hand; each hand's topics are published under `/hand_left` and `/hand_right` by detected handedness
+- Smooth homing (`home.launch.py` / `home.py`): interpolates every joint to zero over a configurable `duration` then exits; `hand_names` homes one or more hands at once
+- `wujihand_list` tool to print the serial numbers of connected WujiHand devices
+- `hand_side` parameter for `wujihand.launch.py` to connect a hand by handedness (`left`/`right`) when no `serial_number` is given
+- `name_by_handedness` driver parameter to root a hand's topics and services at `/hand_<handedness>/`
+
 ## [1.0.1] - 2026-01-21
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds the `CHANGELOG.md` `[Unreleased]` entries for the dual-hand launch, smooth
homing, and the `hand_side` / `name_by_handedness` driver parameters that landed
in #52 — the changelog update was missed in that PR.

No code changes.

## Related
Work item: m-7005928076

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能

* 一键双手启动：自动发现并启动两只手，按检测的手侧类型发布到相应主题
* 平滑回零功能：支持可配置时长的平滑关节回零
* 设备列表工具：快速查看已连接的设备信息
* 灵活的手侧配置：驱动支持按手侧自动管理命名空间和主题路由

<!-- end of auto-generated comment: release notes by coderabbit.ai -->