### PR TITLE
fix(ci): auto-release-on-pr 触发分支改为 main

### DIFF
--- a/.github/workflows/auto-release-on-pr.yml
+++ b/.github/workflows/auto-release-on-pr.yml
@@ -3,7 +3,7 @@ name: Auto Release on PR Merge
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
 
 jobs:
   create-tag:


### PR DESCRIPTION
## 问题

默认分支已从 `master` 改名为 `main`,但 `.github/workflows/auto-release-on-pr.yml` 的触发条件仍写死 `branches: [master]`。

结果:带 `auto-release` 标签、源分支 `release/v*` 的 PR 合并进 `main` 时,create-tag job **完全不会被触发**(GitHub 对不匹配 `branches` 过滤的事件直接忽略),导致不自动打 tag、不发布。

#57 (`release/v1.1.0` → `main`) 就是因此没自动发布;v1.1.0 已手动补打 tag 发出。

## 改动

`branches: [master]` → `branches: [main]`,一行。

## 影响

合并后,后续 `release/v*` + `auto-release` 标签的 PR 合入 `main` 即可自动打 tag → 触发 release。

> 备注(本 PR 不处理):`auto-release.yml` 与 `release.yml` 都在 tag push 时建 Release,目前两者都能成功(已在 v1.1.0 验证),但属冗余,建议后续对齐 handpy 单文件方案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新自动发布工作流的触发分支配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->