### PR TITLE
docs(readme): add wujihandcpp SDK install step before colcon build

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,32 @@ ROS2 driver package for Wuji Hand dexterous hand. Provides 1000Hz joint state pu
 
 ### Installation
 
+The driver links against the **wujihandcpp** C++ SDK, which is distributed
+separately (it is **not** a git submodule, so `git submodule update` does not
+provide it). Install the SDK `.deb` **before** running `colcon build`.
+
 ```bash
 git clone --recurse-submodules https://github.com/wuji-technology/wujihandros2.git
 cd wujihandros2
 # If already cloned without --recurse-submodules, run:
 # git submodule update --init --recursive
+
+# Install the wujihandcpp C++ SDK from the wujihandpy releases.
+# Fetch the latest amd64 .deb (use *-arm64.deb on ARM):
+DEB_URL=$(curl -sH "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/wuji-technology/wujihandpy/releases | \
+  grep -oP '"browser_download_url":\s*"\K[^"]*wujihandcpp[^"]*-amd64\.deb' | head -1)
+wget -q "$DEB_URL"
+sudo dpkg -i --force-overwrite wujihandcpp-*.deb
+sudo apt-get install -f -y
+
 source /opt/ros/humble/setup.bash  # or kilted
 colcon build
 source install/setup.bash
 ```
+
+> The SDK can also be downloaded manually from the
+> [wujihandpy releases page](https://github.com/wuji-technology/wujihandpy/releases).
 
 ### Running
 


### PR DESCRIPTION
## What

Adds the missing **wujihandcpp C++ SDK install step** to the README Installation section, before `colcon build`.

## Why

The driver links against the `wujihandcpp` C++ SDK, but the README's quick-start jumps straight from `git submodule update` to `colcon build`. The SDK is **not** a git submodule (the only submodule is `external/wuji-description`), so following the README as-is fails to build on a clean machine — `colcon build` can't find SDK headers/symbols such as `Hand::Side` and `transport/usb_enumerate.hpp` (used by the `hand_side` param and the `wujihand_list` tool / dual-hand bringup).

Verified on a real bench: with an older locally-installed SDK the new features fail to compile; installing the SDK `.deb` from the `wujihandpy` releases (the same source the release/CI workflow uses) builds and runs all features cleanly.

## Change

- Note that `wujihandcpp` is distributed separately (not a submodule) and must be installed first.
- Add the `.deb` install commands (mirroring `.github/workflows/release.yml`/`ci.yml`), plus a link to the wujihandpy releases page for manual download.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新快速开始指南中的安装说明，新增详细的SDK安装步骤，包括下载、安装依赖包和环境配置等完整流程说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->