### PR TITLE
ci: 新增 docs-prerelease 保鲜 workflow

### DIFF
--- a/.github/workflows/docs-prerelease-sync.yml
+++ b/.github/workflows/docs-prerelease-sync.yml
@@ -1,0 +1,94 @@
+# 源仓保鲜 workflow 模板：main 上 docs/external/ 有 push 时自动 merge 进 docs-prerelease。
+# 由 scripts/rollout-docs-prerelease.sh 铺开到各源仓的 .github/workflows/ 下。
+# 注意：默认分支为 master 的仓库（如 wh110-firmware），rollout 脚本会替换 branches 触发项。
+name: Sync default branch into docs-prerelease
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/external/**"
+
+concurrency:
+  group: docs-prerelease-sync
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge into docs-prerelease
+        id: merge
+        run: |
+          set -euo pipefail
+          if ! git ls-remote --exit-code --heads origin docs-prerelease >/dev/null; then
+            echo "docs-prerelease branch not found, skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # checkout 的 fetch refspec 不保证包含 docs-prerelease，显式取回为本地分支
+          git fetch origin docs-prerelease:docs-prerelease
+          git checkout docs-prerelease
+          if git merge -m "chore: merge ${GITHUB_REF_NAME} into docs-prerelease" "${GITHUB_SHA}"; then
+            git push origin docs-prerelease
+            echo "Merged ${GITHUB_REF_NAME} (${GITHUB_SHA}) into docs-prerelease"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            git merge --abort
+            exit 1
+          fi
+
+      - name: Open conflict issue
+        if: failure() && steps.merge.outputs.conflict == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'docs-prerelease 合并冲突：需要人工处理';
+            const label = 'docs-prerelease-conflict';
+            // 创建 issue 不会自动生成缺失的 label，先幂等创建，保证打标和按标去重生效
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'd93f0b',
+                description: 'docs-prerelease 自动合并冲突，待人工处理',
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e;
+            }
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+            if (issues.some(i => i.title === title)) {
+              console.log('Conflict issue already open, skipping');
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: [label],
+              body: [
+                `自动 merge \`${context.payload.ref.replace('refs/heads/', '')}\` → \`docs-prerelease\` 时发生冲突。`,
+                '',
+                `触发 commit：${context.sha}`,
+                `Workflow run：${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '',
+                '请本地手动 merge 解决冲突后 push docs-prerelease，然后关闭本 issue。',
+              ].join('\n'),
+            });


### PR DESCRIPTION
main 上 docs/external/ 有 push 时自动 merge 进 docs-prerelease 发布列车分支，冲突时开 issue 通知人工处理。

背景：功能类文档改走 docs-prerelease 分支、双周发布日统一合入，日常维护发版不再提前带出未发布内容。流程见 wuji-docs-center 的 RELEASING.md。

说明：本仓受组织级 ruleset（public-repo-branch-protection）限制无法直接创建上游分支，本 PR 按惯例走 Fork and Pull。上游 docs-prerelease 分支由 wuji-automation App 创建。