### PR TITLE
chore(docs-followup): prompt 模板新增发布列车分支与合入目标段

### DIFF
--- a/.github/scripts/docs-followup/docs-followup-prompt.sh
+++ b/.github/scripts/docs-followup/docs-followup-prompt.sh
@@ -44,6 +44,11 @@ cat <<EOF
 - 只关注用户可感知变更（${SURFACE_HINT}）
 - 忽略 ${NOISE_HINT}
 
+分支与合入目标（发布列车）：
+- 判定需要改文档时，从 \`docs-prerelease\` 拉跟进分支，PR base 也用 \`docs-prerelease\`。线上文档由每日 tag 从各仓 main 构建，直接合 main 会把未发布功能的文档提前带上线。列车分支在双周发布日统一合入 main，main 的日常变更由保鲜 workflow 自动同步进列车分支
+- 本仓是公开仓，受组织 ruleset 限制无法向上游推新分支：推到个人 fork，从 fork 向上游提 PR，base 仍是上游 \`docs-prerelease\`
+- 涉及 docs-center 侧配套变更（meta.json 导航注册、reading-guide.json）时，同样走 wuji-docs-center 的 \`docs-prerelease\`
+
 写作规范：
 - 遵守 Microsoft Writing Style Guide
 - 中文：删除"的/了/进行"等冗余词；用阿拉伯数字；主动语态、现在时


### PR DESCRIPTION
## Summary

- 与中心仓 wuji-docs-center 的 prompt 模板同步：新增「分支与合入目标（发布列车）」段
- 明确跟进产物固定 base `docs-prerelease`，防止未发布功能文档随每日 tag 提前上线
- 本仓模板为自托管副本（不依赖中心仓 repos.json），中心仓变更需手动同步，本 PR 即该同步

对应中心仓变更：wuji-technology/wuji-docs-center 同名分支 PR。

## 自测结果

- 冒烟渲染：`REPO=wuji-technology/wujihandros2 PR_NUMBER=999 PR_TITLE=smoke PR_AUTHOR=tester bash .github/scripts/docs-followup/docs-followup-prompt.sh`，新段落渲染正常，反引号转义无误
- pr-review-toolkit 本地审查通过，与中心仓模板语义一致（仅"本仓是公开仓"视角措辞差异）

🤖 Generated with [Claude Code](https://claude.com/claude-code)