### PR TITLE
ci(docs-followup): prompt 模板补版本发布记录规则段

### DIFF
--- a/.github/scripts/docs-followup/docs-followup-prompt.sh
+++ b/.github/scripts/docs-followup/docs-followup-prompt.sh
@@ -44,6 +44,11 @@ cat <<EOF
 - 只关注用户可感知变更（${SURFACE_HINT}）
 - 忽略 ${NOISE_HINT}
 
+对外性判定（判断"用户可感知"的依据，2026-07-09 强化）：
+- 依据是本仓对外 API 面（.pyi / 导出类型 / ROS 接口 / 头文件等）里的公开符号 + PR 的 Breaking / 新 API 标记，不是 CHANGELOG 是否已记。changelog 缺失是"应记未记"，不能反推"无需跟进"
+- Breaking 变更、或公开符号新增 / 签名变更：即使 changelog 未记、即使当前文档无对应章节，也要跟进（无章节就新建承载），不可判 skip
+- 确属对外但 CHANGELOG [Unreleased] 未记 → 在跟进结论里提醒源 PR 作者补记，这是发布记录的唯一取材源，漏记会导致发版漏条目，但缺失本身不作为 skip 理由
+
 版本发布记录（与正文承载独立判定，2026-07-09 起）：
 - 本仓 docs/external 不承载 release-notes 页面，版本发布记录由发版流程从本仓 CHANGELOG.md 聚合生成到文档中心对应产品页
 - 跟进时确认源 PR 的用户可感知变化已记入 CHANGELOG.md 的 [Unreleased] 段（以 origin/main 为准）：缺失 → 在跟进报告里点名提醒源 PR 作者补记，发布记录以 [Unreleased] 为唯一取材来源，漏记会导致发版漏条目

--- a/.github/scripts/docs-followup/docs-followup-prompt.sh
+++ b/.github/scripts/docs-followup/docs-followup-prompt.sh
@@ -44,6 +44,11 @@ cat <<EOF
 - 只关注用户可感知变更（${SURFACE_HINT}）
 - 忽略 ${NOISE_HINT}
 
+版本发布记录（与正文承载独立判定，2026-07-09 起）：
+- 本仓 docs/external 不承载 release-notes 页面，版本发布记录由发版流程从本仓 CHANGELOG.md 聚合生成到文档中心对应产品页
+- 跟进时确认源 PR 的用户可感知变化已记入 CHANGELOG.md 的 [Unreleased] 段（以 origin/main 为准）：缺失 → 在跟进报告里点名提醒源 PR 作者补记，发布记录以 [Unreleased] 为唯一取材来源，漏记会导致发版漏条目
+- 已随既往版本发布的变化无需处理
+
 分支与合入目标（发布列车）：
 - 判定需要改文档时，从 \`docs-prerelease\` 拉跟进分支，PR base 也用 \`docs-prerelease\`。线上文档由每日 tag 从各仓 main 构建，直接合 main 会把未发布功能的文档提前带上线。列车分支在双周发布日统一合入 main，main 的日常变更由保鲜 workflow 自动同步进列车分支
 - 本仓是公开仓，受组织 ruleset 限制无法向上游推新分支：推到个人 fork，从 fork 向上游提 PR，base 仍是上游 \`docs-prerelease\`


### PR DESCRIPTION
## 背景

docs-followup 流程 2026-07-09 起新增「版本发布记录判定」（中心仓模板已更新：wuji-technology/wuji-docs-center#229）。本仓 prompt 模板为自托管副本，按「模板联动维护」三处同步。

## 变更

「判断规则」与「分支与合入目标」之间插入版本发布记录段，按本仓现实适配：docs/external 不承载 release-notes 页面，跟进时确认变化已记入 CHANGELOG [Unreleased]（发布记录唯一取材来源），缺失则提醒源 PR 作者补记。

## 自测

- `REPO=... PR_NUMBER=999 PR_TITLE=smoke PR_AUTHOR=tester bash .github/scripts/docs-followup/docs-followup-prompt.sh` 渲染正常，新段落在位

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新了文档跟进提示说明，强化“用户可感知/是否需跟进”的判定依据。
  * 新增“版本发布记录（自 2026-07-09 起）”说明：由发版流程从仓库 `CHANGELOG.md` 的 `[Unreleased]` 段聚合生成，`[Unreleased]` 为唯一取材源。
  * 若属于对外但 `[Unreleased]` 漏记，将在跟进报告中提醒补记；已随既往版本发布的内容无需额外处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->