### PR TITLE
ci(docs-followup): 维护者跳过改为名单，新增 xialiC

### DIFF
--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -59,12 +59,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Maintainer-authored PRs: silently skip. The `silent:` prefix on
-          # `reason` tells notify-skip to suppress its Feishu card too.
-          if [[ -n "$DOCS_MAINTAINER" && "$PR_AUTHOR" == "$DOCS_MAINTAINER" ]]; then
-            echo "skip: author=$PR_AUTHOR matches DOCS_MAINTAINER, silently skipping" >&2
+          # 文档维护者名单内作者提的 PR：静默跳过，不发任何卡片。名单里的人本身就是
+          # 收卡片的人，自己提的东西不需要再收一份通知。`silent:` 前缀让 notify-skip
+          # 连「不需要文档跟进」的灰卡也不发（见 notify-skip 的 if 守卫），否则维护者
+          # 每提一个 docs: 前缀的 PR 都会被自己的机器人打扰一次。
+          #
+          # 名单 = vars.DOCS_MAINTAINER（org 变量，同时是 /docs-done 的授权人）
+          #      + DOCS_SKIP_AUTHORS（下面这行维护的附加名单，逗号分隔）
+          # 判「作者」而不是「合入人」：两者常常不同（bot 提、维护者合），按合入人
+          # 判会把同事的功能 PR 一起静默掉，真通知就丢了。
+          DOCS_SKIP_AUTHORS="yuanyuanxin,xialiC"
+          SKIP_LIST=",${DOCS_MAINTAINER},${DOCS_SKIP_AUTHORS},"
+          if [[ -n "$PR_AUTHOR" && "$SKIP_LIST" == *",${PR_AUTHOR},"* ]]; then
+            echo "skip: author=$PR_AUTHOR is on the docs skip list, silently skipping" >&2
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "reason=silent:author-is-docs-maintainer" >> "$GITHUB_OUTPUT"
+            echo "reason=silent:author-on-docs-skiplist" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## 背景

维护者跳过原来只认单个 `vars.DOCS_MAINTAINER`，其他文档维护者提的 PR 仍会触发通知卡片。

`xialiC` 提的 `docs: ... quality design` 类 PR 每次都命中标题前缀跳过，于是每提一个就往维护者那里发一张「不需要文档跟进」的灰卡——纯噪声。

## 变更

改为名单判定：`vars.DOCS_MAINTAINER` + 附加名单 `DOCS_SKIP_AUTHORS`（逗号分隔），命中任一即静默跳过（`silent:` 前缀连灰卡也不发）。

**判「作者」而不是「合入人」**：两者常常不同（bot 提、维护者合）。按合入人判会把维护者合入的同事功能 PR 一起静默掉，真通知就丢了。

## 自测结果

- `yaml.safe_load` 解析通过
- 用 10 位真实作者跑判定：名单内 2 人静默跳过，其余 8 人（Burppp / MyFirstGit-01 / zengguizhang / drindr / ThirteenLLB / christopheralex-cc / degaungouyang / wuji-tech-dev）全部正常判定，无误伤
- 边界：`DOCS_MAINTAINER` 为空时名单仍生效；作者名为空不误匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 扩展文档跟进流程的作者跳过名单，符合条件的请求将自动静默跳过。
  * 保持其余处理流程不变，减少不必要的后续操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->