### PR TITLE
ci: scope app token to docs center and JSON-encode dispatch payload

### DIFF
--- a/.github/workflows/notify-docs-preview.yml
+++ b/.github/workflows/notify-docs-preview.yml
@@ -18,7 +18,7 @@ jobs:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
-
+          repositories: wuji-docs-center
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -26,8 +26,8 @@ jobs:
           event-type: docs-preview
           client-payload: |
             {
-              "repo": "${{ github.event.repository.name }}",
-              "branch": "${{ github.head_ref }}",
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "sha": "${{ github.event.pull_request.head.sha }}"
+              "repo": ${{ toJSON(github.event.repository.name) }},
+              "branch": ${{ toJSON(github.head_ref) }},
+              "pr_number": ${{ toJSON(github.event.pull_request.number) }},
+              "sha": ${{ toJSON(github.event.pull_request.head.sha) }}
             }

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -17,7 +17,7 @@ jobs:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
-
+          repositories: wuji-docs-center
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -26,5 +26,5 @@ jobs:
           client-payload: |
             {
               "repo": "wujihandros2",
-              "sha": "${{ github.sha }}"
+              "sha": ${{ toJSON(github.sha) }}
             }


### PR DESCRIPTION
Scope the GitHub App token to the dispatch target repository instead of the whole installation, and wrap dynamic client-payload fields in toJSON so branch names with special characters cannot produce invalid JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化文档相关自动化通知流程的数据传递格式。
  * 限定访问范围至指定文档仓库，提升流程安全性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->