### PR TITLE
ci: harden docs workflows for fork PR context

### DIFF
--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -25,7 +25,13 @@ name: Post-Merge Docs Follow-up
 #   - .github/scripts/docs-followup/*.sh
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no secrets and a
+  # read-only GITHUB_TOKEN under pull_request, which would break labeling,
+  # PR comments, and the Feishu DM for merged fork PRs. All jobs check out
+  # and execute scripts from the BASE repo only (actions/checkout default
+  # under pull_request_target — no ref: override), never PR head code, so
+  # this is safe.
+  pull_request_target:
     types: [closed]
     branches: [main]
 

--- a/.github/workflows/docs-prerelease-sync.yml
+++ b/.github/workflows/docs-prerelease-sync.yml
@@ -1,6 +1,4 @@
-# 源仓保鲜 workflow 模板：main 上 docs/external/ 有 push 时自动 merge 进 docs-prerelease。
-# 由 scripts/rollout-docs-prerelease.sh 铺开到各源仓的 .github/workflows/ 下。
-# 注意：默认分支为 master 的仓库（如 wh110-firmware），rollout 脚本会替换 branches 触发项。
+# 源仓保鲜 workflow：默认分支上 docs/external/ 有 push 时自动 merge 进 docs-prerelease。
 name: Sync default branch into docs-prerelease
 
 on:

--- a/.github/workflows/notify-docs-preview.yml
+++ b/.github/workflows/notify-docs-preview.yml
@@ -19,6 +19,9 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
           repositories: wuji-docs-center
+          # repository_dispatch only needs contents: write — don't inherit
+          # the installation's full permission set.
+          permission-contents: write
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -18,6 +18,9 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
           repositories: wuji-docs-center
+          # repository_dispatch only needs contents: write — don't inherit
+          # the installation's full permission set.
+          permission-contents: write
       - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## 变更内容

docs workflow 安全加固，修复 fork PR 场景失效：

- **触发器改 `pull_request_target`**（`docs-followup.yml`）：本仓绝大多数合入 PR 来自 fork。fork PR 在 `pull_request` 下拿到只读 token 且无 secrets，导致打 `docs:followup` 标签、PR 评论、文档中心通知全部静默失效。改后 fork PR 也能拿到写权限与 secrets。checkout 取 base 仓（无 `ref:` 覆盖），不执行 PR head 代码。
- **App token 最小权限**（`notify-docs.yml` + `notify-docs-preview.yml`）：`repository_dispatch` 只需 `contents: write`，显式限定。
- **脱敏**（`docs-prerelease-sync.yml`）：去掉头注释里的私有仓名。

## 保留项

`notify-docs-preview.yml` 的触发器**不改**：它有 same-repo guard（`head.repo == repository`），设计上就只给同仓 PR 发 preview，是既定产品取向而非 bug，本次只加权限最小化。

## 背景

本仓 docs workflow 从共享模板 rollout。同族公开仓 wuji-mjlab 已先行加固（wuji-technology/wuji-mjlab#8），本 PR 与 wujihandpy 对齐同一套修复。

## 自测结果

- 4 个 workflow YAML 解析通过
- checkout 步骤全部无 `ref:` 覆盖，`pull_request_target` 下取 base 仓，安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化文档相关自动化流程的权限配置，确保文档预览和文档更新通知能够稳定触发。
  * 调整外部贡献内容的处理方式，提升自动化流程的安全性，避免影响后续标签、评论及通知操作。
  * 简化文档预发布同步流程的说明，保持现有同步行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->